### PR TITLE
add functional tests for obal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,7 +35,6 @@ wheels/
 #  Usually these files are written by a python script from a template
 #  before PyInstaller builds the exe, so as to inject date/other infos into it.
 *.manifest
-*.spec
 
 # Installer logs
 pip-log.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ python:
 - '2.7'
 install:
 - pip install -r requirements-test.txt
+- curl --create-dirs -o /home/travis/.local/bin/spectool https://pagure.io/rpmdevtools/raw/master/f/spectool.in
+- chmod +x /home/travis/.local/bin/spectool
 script:
 - tox
 deploy:
@@ -13,3 +15,10 @@ deploy:
     secure: HmlFYR1Nn325ZYPTWOorcw2qSQNrpxOiEmi3sd3EhVNlk0sR0582ujNY2cLquLxQkFFs3cjDdUVz1FNHC0PX5nOSbA7P0Ks4xZoU2MeXq+HLlreB2w2qcp2XfJXbSFh8ZfqoMCw83lsHkTBwkCYpy/jF6FNUSiP0hWp0aYNMVKwaLB2V8YggkyYStUqtLyq8BlKP1bxWqZTjVia9sk5ZpzG+sDMC/rzwlYDRzk6u9UFITmav6ONCFIsiwBuOTa9KcON21PQGJOBnP3HJB3iyPcGKI/3Ln5aUKVn36tN5hNu3s8VkqVumpxZir5qpqplsJdpY9tRwUTGyVP+CVA8wjxJYP3ziRQpJeHXVdDQ3pU1t9uOPp5Zgfp1Xbbl5QhcAQkHedQ27Xc3WlKdgXZO4dQpTnuFPW71j/J4EM29M1/0RecSYrVvefqWk7ZhIgX4VHydzM9n7VJcIGjXkY5JIWTgEwbXsw9E58iktefYy7+q/z059e0m3+vLJmuWIE+eucmN9pWdunS6GEL8fq9XDL5egtf0c//+mrjHj4u90+8w+TjzdVduqQyQVI3MZ68eM+Wlz0ChjOk32l2N9CmNjGXRFog2YbazZaJT0Z+mRMUlyQUNr6nzC4smsqX8UqzrdHI/g6s9klNoNWdjTF4afewElkQtX9NT0m5SVWAr12hg=
   on:
     tags: true
+script:
+  - tox
+addons:
+  apt:
+    packages:
+    - git-annex
+    - rpm

--- a/obal/data/update_package.yml
+++ b/obal/data/update_package.yml
@@ -2,6 +2,8 @@
 - hosts: packages
   serial: 1
   gather_facts: no
+  roles:
+    - git_annex_setup
   tasks:
     - name: 'Ensure upstream_files is defined'
       fail:

--- a/tests/fixtures/mockbin/brew
+++ b/tests/fixtures/mockbin/brew
@@ -1,0 +1,1 @@
+mockbin

--- a/tests/fixtures/mockbin/koji
+++ b/tests/fixtures/mockbin/koji
@@ -1,0 +1,1 @@
+mockbin

--- a/tests/fixtures/mockbin/mockbin
+++ b/tests/fixtures/mockbin/mockbin
@@ -1,0 +1,10 @@
+#!/usr/bin/env python2
+
+import os
+import sys
+
+mockbin_log = os.environ.get('MOCKBIN_LOG', None)
+
+if mockbin_log:
+    with open(mockbin_log, 'a') as logfile:
+        logfile.write("%s\n" % sys.argv)

--- a/tests/fixtures/mockbin/tito
+++ b/tests/fixtures/mockbin/tito
@@ -1,0 +1,1 @@
+mockbin

--- a/tests/fixtures/testrepo/downstream/package_manifest.yaml
+++ b/tests/fixtures/testrepo/downstream/package_manifest.yaml
@@ -1,0 +1,15 @@
+---
+packages:
+  vars:
+    diff_brew_package_skip: false
+    build_package_koji_command: 'brew'
+    satellite_version: '6.3.0'
+    foremandist: 'fm1_15'
+    releasers:
+      - obaltest-dist-git-rhel-7
+  hosts:
+    hello:
+      upstream: "../../upstream/.git"
+      branch: "master"
+      upstream_files:
+        - "packages/hello/"

--- a/tests/fixtures/testrepo/downstream/packages/hello/hello.spec
+++ b/tests/fixtures/testrepo/downstream/packages/hello/hello.spec
@@ -1,0 +1,51 @@
+# taken verbatim from
+# https://fedoraproject.org/wiki/How_to_create_a_GNU_Hello_RPM_package
+Name:           hello
+Version:        2.9
+Release:        1%{?dist}
+Summary:        The "Hello World" program from GNU
+
+License:        GPLv3+
+URL:            http://ftp.gnu.org/gnu/%{name}
+Source0:        http://ftp.gnu.org/gnu/%{name}/%{name}-%{version}.tar.gz
+
+BuildRequires: gettext
+
+Requires(post): info
+Requires(preun): info
+
+%description
+The "Hello World" program, done with all bells and whistles of a proper FOSS
+project, including configuration, build, internationalization, help files, etc.
+
+%prep
+%autosetup
+
+%build
+%configure
+make %{?_smp_mflags}
+
+%install
+%make_install
+%find_lang %{name}
+rm -f %{buildroot}/%{_infodir}/dir
+
+%post
+/sbin/install-info %{_infodir}/%{name}.info %{_infodir}/dir || :
+
+%preun
+if [ $1 = 0 ] ; then
+/sbin/install-info --delete %{_infodir}/%{name}.info %{_infodir}/dir || :
+fi
+
+%files -f %{name}.lang
+%{_mandir}/man1/hello.1.*
+%{_infodir}/hello.info.*
+%{_bindir}/hello
+
+%doc AUTHORS ChangeLog NEWS README THANKS TODO
+%license COPYING
+
+%changelog
+* Tue Sep 06 2011 The Coon of Ty <Ty@coon.org> 2.10-1
+- Initial version of the package

--- a/tests/fixtures/testrepo/empty/package_manifest.yaml
+++ b/tests/fixtures/testrepo/empty/package_manifest.yaml
@@ -1,0 +1,15 @@
+---
+packages:
+  vars:
+    diff_brew_package_skip: false
+    build_package_koji_command: 'brew'
+    satellite_version: '6.3.0'
+    foremandist: 'fm1_15'
+    releasers:
+      - obaltest-dist-git-rhel-7
+  hosts:
+    hello:
+      upstream: "../../upstream/.git"
+      branch: "master"
+      upstream_files:
+        - "packages/hello/"

--- a/tests/fixtures/testrepo/upstream/package_manifest.yaml
+++ b/tests/fixtures/testrepo/upstream/package_manifest.yaml
@@ -1,0 +1,7 @@
+---
+packages:
+  vars:
+    releasers:
+      - dist-git
+  hosts:
+    hello: {}

--- a/tests/fixtures/testrepo/upstream/packages/hello/hello.spec
+++ b/tests/fixtures/testrepo/upstream/packages/hello/hello.spec
@@ -1,0 +1,51 @@
+# taken verbatim from
+# https://fedoraproject.org/wiki/How_to_create_a_GNU_Hello_RPM_package
+Name:           hello
+Version:        2.10
+Release:        1%{?dist}
+Summary:        The "Hello World" program from GNU
+
+License:        GPLv3+
+URL:            http://ftp.gnu.org/gnu/%{name}
+Source0:        http://ftp.gnu.org/gnu/%{name}/%{name}-%{version}.tar.gz
+
+BuildRequires: gettext
+
+Requires(post): info
+Requires(preun): info
+
+%description
+The "Hello World" program, done with all bells and whistles of a proper FOSS
+project, including configuration, build, internationalization, help files, etc.
+
+%prep
+%autosetup
+
+%build
+%configure
+make %{?_smp_mflags}
+
+%install
+%make_install
+%find_lang %{name}
+rm -f %{buildroot}/%{_infodir}/dir
+
+%post
+/sbin/install-info %{_infodir}/%{name}.info %{_infodir}/dir || :
+
+%preun
+if [ $1 = 0 ] ; then
+/sbin/install-info --delete %{_infodir}/%{name}.info %{_infodir}/dir || :
+fi
+
+%files -f %{name}.lang
+%{_mandir}/man1/hello.1.*
+%{_infodir}/hello.info.*
+%{_bindir}/hello
+
+%doc AUTHORS ChangeLog NEWS README THANKS TODO
+%license COPYING
+
+%changelog
+* Tue Sep 06 2011 The Coon of Ty <Ty@coon.org> 2.10-1
+- Initial version of the package

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -1,0 +1,189 @@
+import functools
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import pytest
+import obal
+
+
+FIXTURE_DIR = os.path.join(
+    os.path.dirname(os.path.realpath(__file__)),
+    'fixtures',
+)
+
+TESTREPO_DIR = os.path.join(FIXTURE_DIR, 'testrepo')
+MOCKBIN_DIR = os.path.join(FIXTURE_DIR, 'mockbin')
+
+DEFAULT_ARGS = []
+if os.environ.get('TRAVIS', None):
+    DEFAULT_ARGS.extend(['-e', 'ansible_remote_tmp=/tmp/ansible-remote'])
+
+
+def obal_cli_test(func=None, repotype='upstream'):
+    if func is None:
+        return functools.partial(obal_cli_test, repotype=repotype)
+
+    @functools.wraps(func)
+    def func_wrapper(*args, **kwargs):
+        tempdir = tempfile.mkdtemp()
+        repodir = os.path.join(tempdir, 'repo')
+        shutil.copytree(TESTREPO_DIR, repodir)
+
+        oldcwd = os.getcwd()
+        oldpath = os.environ['PATH']
+        os.chdir(os.path.join(repodir, repotype))
+        os.environ['PATH'] = "{}:{}".format(MOCKBIN_DIR, oldpath)
+        os.environ['MOCKBIN_LOG'] = os.path.join(tempdir, 'mockbin.log')
+
+        subprocess.check_call(['git', 'init'])
+
+        func(*args, **kwargs)
+
+        os.chdir(oldcwd)
+        os.environ['PATH'] = oldpath
+        os.environ.pop('MOCKBIN_LOG')
+
+        shutil.rmtree(tempdir, ignore_errors=True)
+
+    return func_wrapper
+
+
+def run_obal(args, exitcode):
+    sys.argv = ['obal'] + DEFAULT_ARGS + args
+    with pytest.raises(SystemExit) as excinfo:
+        obal.main()
+    assert excinfo.value.code == exitcode
+
+
+def assert_obal_success(args):
+    run_obal(args, 0)
+
+
+def assert_obal_failure(args):
+    run_obal(args, 2)
+
+
+def assert_mockbin_log(content):
+    expected_log = "\n".join(content)
+    expected_log = expected_log.replace('{bin}', MOCKBIN_DIR)
+    with open(os.environ['MOCKBIN_LOG']) as mockbinlog:
+        log = mockbinlog.read().strip()
+        assert log == expected_log
+
+
+def setup_upstream(upstream_path):
+    # create a cloneable upstream repo, what we ship in fixtures is not
+    subprocess.check_call(['git', 'init'], cwd=upstream_path)
+    subprocess.check_call(['git', 'annex', 'init'], cwd=upstream_path)
+    subprocess.check_call(['git', 'add', '.'], cwd=upstream_path)
+    subprocess.check_call(['git', 'annex', 'addurl', '--file',
+                           'packages/hello/hello-2.10.tar.gz',
+                           'http://ftp.gnu.org/gnu/hello/hello-2.10.tar.gz'],
+                          cwd=upstream_path)
+    subprocess.check_call(['git', 'commit', '-a', '-m', 'init'],
+                          cwd=upstream_path)
+
+
+@obal_cli_test(repotype='upstream')
+def test_obal_noargs():
+    assert_obal_failure([])
+
+
+@obal_cli_test(repotype='upstream')
+def test_obal_scratch_upstream_hello():
+    assert_obal_success(['scratch', 'hello'])
+
+    assert os.path.exists('packages/hello/hello-2.10.tar.gz')
+
+    expected_log = [
+        "['{bin}/tito', 'release', '--scratch', 'dist-git', '-y']"
+    ]
+    assert_mockbin_log(expected_log)
+
+
+@obal_cli_test(repotype='upstream')
+def test_obal_release_upstream_hello():
+    assert_obal_success(['release', 'hello'])
+
+    assert os.path.exists('packages/hello/hello-2.10.tar.gz')
+
+    expected_log = [
+        "['{bin}/tito', 'release', 'dist-git', '-y']",
+    ]
+    assert_mockbin_log(expected_log)
+
+
+@obal_cli_test(repotype='downstream')
+def test_obal_scratch_downstream_hello():
+    assert_obal_success(['scratch', 'hello'])
+
+    assert os.path.exists('packages/hello/hello-2.9.tar.gz')
+
+    expected_log = [
+        "['{bin}/tito', 'release', 'obaltest-scratch-rhel-7', '-y']"
+    ]
+    assert_mockbin_log(expected_log)
+
+
+@obal_cli_test(repotype='downstream')
+def test_obal_release_downstream_hello():
+    assert_obal_success(['release', 'hello'])
+
+    assert os.path.exists('packages/hello/hello-2.9.tar.gz')
+
+    expected_log = [
+        "['{bin}/brew', 'list-tagged', '--quiet', 'satellite-6.3.0-rhel-7-candidate', 'hello']",  # noqa: E501
+        "['{bin}/tito', 'release', 'obaltest-dist-git-rhel-7', '-y']",
+    ]
+    assert_mockbin_log(expected_log)
+
+
+@obal_cli_test(repotype='downstream')
+def test_obal_scratch_downstream_hello_wait():
+    assert_obal_success(['scratch', 'hello', '--tags', 'wait,download'])
+
+    assert os.path.exists('packages/hello/hello-2.9.tar.gz')
+
+    expected_log = [
+        "['{bin}/tito', 'release', 'obaltest-scratch-rhel-7', '-y']",
+        "['{bin}/brew', 'watch-task']",
+        "['{bin}/brew', 'download-logs', '-r']",
+    ]
+    assert_mockbin_log(expected_log)
+
+
+@obal_cli_test(repotype='downstream')
+def test_obal_release_downstream_hello_wait():
+    assert_obal_success(['release', 'hello', '--tags', 'wait,download'])
+
+    assert os.path.exists('packages/hello/hello-2.9.tar.gz')
+
+    expected_log = [
+        "['{bin}/brew', 'list-tagged', '--quiet', 'satellite-6.3.0-rhel-7-candidate', 'hello']",  # noqa: E501
+        "['{bin}/tito', 'release', 'obaltest-dist-git-rhel-7', '-y']",
+        "['{bin}/brew', 'watch-task']",
+        "['{bin}/brew', 'download-logs', '-r']",
+    ]
+    assert_mockbin_log(expected_log)
+
+
+@obal_cli_test(repotype='downstream')
+def test_obal_update_downstream_hello():
+    setup_upstream('../upstream/')
+
+    assert_obal_success(['update', 'hello'])
+
+    assert not os.path.exists('packages/hello/hello-2.9.tar.gz')
+    assert not os.path.islink('packages/hello/hello-2.9.tar.gz')
+    assert os.path.islink('packages/hello/hello-2.10.tar.gz')
+
+
+@obal_cli_test(repotype='empty')
+def test_obal_add_downstream_hello():
+    setup_upstream('../upstream/')
+
+    assert_obal_success(['add', 'hello'])
+
+    assert os.path.islink('packages/hello/hello-2.10.tar.gz')

--- a/tox.ini
+++ b/tox.ini
@@ -13,13 +13,14 @@ deps =
     flake8
     pytest
     pytest-cov
+    pytest-xdist
     coveralls
 commands =
     check-manifest --ignore tox.ini,tests*
     # check -r currently fails
     python setup.py check -m -s
     flake8 setup.py obal tests
-    pytest --cov={envsitepackagesdir}/obal {posargs}
+    pytest --cov={envsitepackagesdir}/obal --boxed {posargs}
     coverage combine
     - coveralls
 passenv = TRAVIS TRAVIS_*


### PR DESCRIPTION
This is still mostly WIP, but I wanted to see what y'all are thinking.

The idea is to have a dummy repository and execute the various tasks we have on it.

# current gotchas

* It sets `ansible_remote_tmp` for Travis, as otherwise this fails there :(
* only downstream and upstream repos available, not pulp
* only `scratch`, `release`, 'add' and `update` are implemented at the moment (and the last two only for downstream repos, as the playbooks don't work for upstream ones yet)

Fixes: #36