### PR TITLE
don't fiddle with sys.argv in the tests

### DIFF
--- a/obal/__init__.py
+++ b/obal/__init__.py
@@ -100,7 +100,7 @@ def generate_ansible_args(inventory_path, playbook_path, args):
     return ansible_args
 
 
-def main():
+def main(cliargs=None):
     packaging_playbooks_path = resource_filename(__name__, 'data')
     cfg_path = os.path.join(packaging_playbooks_path, 'ansible.cfg')
 
@@ -119,7 +119,7 @@ def main():
 
     parser = obal_argument_parser(package_choices)
 
-    args = parser.parse_args()
+    args = parser.parse_args(cliargs)
 
     playbook = _PLAYBOOKS[args.action]
     playbook_path = os.path.join(packaging_playbooks_path, playbook)

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -2,7 +2,6 @@ import functools
 import os
 import shutil
 import subprocess
-import sys
 import tempfile
 import pytest
 import obal
@@ -51,9 +50,8 @@ def obal_cli_test(func=None, repotype='upstream'):
 
 
 def run_obal(args, exitcode):
-    sys.argv = ['obal'] + DEFAULT_ARGS + args
     with pytest.raises(SystemExit) as excinfo:
-        obal.main()
+        obal.main(DEFAULT_ARGS + args)
     assert excinfo.value.code == exitcode
 
 


### PR DESCRIPTION
* allow obal.main() to take cliargs directly and use that in the tests
* "real" cli will still parse that from sys.argv, thanks argparse!