### PR TITLE
Add repoclosure support

### DIFF
--- a/obal/__init__.py
+++ b/obal/__init__.py
@@ -18,6 +18,7 @@ _PLAYBOOKS = {
     'add': 'add_package.yml',
     'check': 'check_package.yml',
     'release': 'release_package.yml',
+    'repoclosure': 'repoclosure.yml',
     'scratch': 'scratch_build.yml',
     'setup': 'setup.yml',
     'update': 'update_package.yml'
@@ -71,6 +72,7 @@ def obal_argument_parser(package_choices):
     parser.add_argument("action",
                         choices=_PLAYBOOKS.keys(),
                         help="""which action to execute""")
+
     parser.add_argument('package',
                         metavar='package',
                         choices=package_choices,

--- a/obal/data/ansible.cfg
+++ b/obal/data/ansible.cfg
@@ -2,5 +2,7 @@
 inventory = package_manifest.yaml
 retry_files_enabled = False
 transport = local
-callback_whitelist = profile_tasks
+callback_whitelist = profile_tasks,debug
 nocows = 1
+stdout_callback = debug
+stderr_callback = debug

--- a/obal/data/repoclosure.yml
+++ b/obal/data/repoclosure.yml
@@ -1,0 +1,4 @@
+- hosts: localhost
+  gather_facts: no
+  roles:
+    - repoclosure

--- a/obal/data/roles/repoclosure/defaults/main.yml
+++ b/obal/data/roles/repoclosure/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+repoclosure_additional_repos:  []
+repoclosure_config: repoclosure/el7.cfg
+repoclosure_target_repo: scratch
+repoclosure_look_aside_repos: []

--- a/obal/data/roles/repoclosure/tasks/main.yml
+++ b/obal/data/roles/repoclosure/tasks/main.yml
@@ -1,0 +1,27 @@
+---
+- name: 'Build additional repos'
+  set_fact:
+    additional_repos: "{{ additional_repos|default([]) + ['--repofrompath=' + item.name + ',' + item.url] }}"
+  with_items: "{{ repoclosure_additional_repos }}"
+
+- name: 'Run repoclosure'
+  command: >
+    repoclosure
+      -c {{ inventory_dir }}/{{ repoclosure_config }}
+      -t
+      -r {{ repoclosure_target_repo }}
+      {{ additional_repos | join(' ') }}
+      {{ '-l ' if repoclosure_look_aside_repos else '' }}
+      {{ repoclosure_look_aside_repos | join(' -l ') }}
+  register: output
+  when: output is not defined
+  args:
+    chdir: "{{ inventory_dir }}"
+
+- name: 'Cleanup'
+  file:
+    state: absent
+    path: "{{ inventory_dir }}/{{ repoclosure_target_repo }}/"
+
+- debug:
+    msg: "{{ output.stdout_lines }}"


### PR DESCRIPTION
From my testing this works and is fairly simple as its a single playbook, however, I am torn on the design. Other ideas:

 * Move repoclosure into a role to make the variables a bit more clean by defining defaults for them, this would make the playbook simply a call to the role
 * Create a repoclosure module to handle the data manipulation this possibly means you could define multiple repoclosures and use with_items to iterate on them (the current solution is to call repoclosure multiple times with the variables needed for each configuration for each repoclosure that needs computed)


One thing that was a bit unclean about this is that repoclosure does not operate on packages. So the call is currently `obal repoclosure all`. The all being the slightly ugly part.