### PR TITLE
stop using tags to limit what we run

### DIFF
--- a/obal/data/roles/build_package/defaults/main.yaml
+++ b/obal/data/roles/build_package/defaults/main.yaml
@@ -4,3 +4,5 @@ build_package_koji_command: koji
 build_package_tito_args: ''
 build_package_scratch: false
 build_package_tito_releaser_args: []
+build_package_wait: true
+build_package_download_logs: false

--- a/obal/data/roles/build_package/tasks/copr.yml
+++ b/obal/data/roles/build_package/tasks/copr.yml
@@ -3,25 +3,17 @@
   set_fact:
     build_package_tito_args: "{{ build_package_tito_args }} --test"
   when: build_package_test|default(false)
-  tags:
-    - always
 
 - block:
     - name: 'Set tito_releasers for copr release'
       set_fact:
         build_package_tito_releasers: "{{ releasers | join(' ') }}"
-      tags:
-        - always
 
     - include_tasks: tito_release.yml
-      tags:
-        - always
 
     - name: 'Wait for tasks to finish'
       include_tasks: wait.yml
-      when: build_package_normal_execution_check is not defined
-      tags:
-        - wait
+      when: build_package_wait|bool
   when: not build_package_scratch
 
 - block:
@@ -30,15 +22,11 @@
         state: directory
         path: "{{ inventory_dir }}/.tmp"
       run_once: true
-      tags:
-        - always
 
     - set_fact:
         copr_repo_name: "{{ copr_user }}/{{ build_package_scratch_repo}}-{{ 999999999 | random | to_uuid }}"
       run_once: true
       when: copr_repo_name is not defined
-      tags:
-        - always
 
     - name: 'Write copr repo name to vars file'
       copy:
@@ -49,25 +37,17 @@
     - include_role:
         name: copr_repo
       run_once: true
-      tags:
-        - always
 
     - name: 'Build SRPM'
       command: 'tito build --srpm --scl={{ scl }}'
       args:
         chdir: "{{ inventory_dir }}/packages/{{ inventory_hostname }}"
       register: srpm_build
-      tags:
-        - always
 
     - name: 'Run build'
-      command: "copr-cli build {{ copr_repo_name }} {{ srpm_build.stdout.split('Wrote: ')[1] }}"
+      command: "copr-cli build {% if not build_package_wait|bool %}--nowait{% endif %} {{ copr_repo_name }} {{ srpm_build.stdout.split('Wrote: ')[1] }}"
       register: build_status
-      tags:
-        - always
 
     - debug:
         msg: "{{ build_status.stdout_lines | join('\n') }}"
-      tags:
-        - always
   when: build_package_scratch|default(false)

--- a/obal/data/roles/build_package/tasks/download.yml
+++ b/obal/data/roles/build_package/tasks/download.yml
@@ -3,5 +3,3 @@
   args:
     chdir: "{{ inventory_dir }}"
   when: (build_package_tito_release | succeeded) and build_package_build_system == 'koji'
-  tags:
-    - always

--- a/obal/data/roles/build_package/tasks/koji.yml
+++ b/obal/data/roles/build_package/tasks/koji.yml
@@ -3,43 +3,28 @@
   set_fact:
     build_package_tito_releasers: "{{ releasers | join(' ') | replace('dist-git', 'scratch') }}"
   when: build_package_koji_command == 'brew' and build_package_scratch|default(false)
-  tags:
-    - always
 
 - name: 'Set tito_releasers'
   set_fact:
     build_package_tito_releasers: "{{ releasers | join(' ')  }}"
-  when: build_package_koji_command != 'brew' or not build_package_scratch|default(false) 
-  tags:
-    - always
+  when: build_package_koji_command != 'brew' or not build_package_scratch|default(false)
 
 - name: 'Set test build'
   set_fact:
       build_package_tito_args: "{{ build_package_tito_args }} --test"
   when: build_package_test|default(false)
-  tags:
-    - always
 
 - name: 'Set scratch build'
   set_fact:
     build_package_tito_args: "{{ build_package_tito_args }} --scratch"
   when: build_package_koji_command != 'brew' and build_package_scratch|default(false)
-  tags:
-    - always
 
 - include_tasks: tito_release.yml
-  tags:
-    - always
 
 - name: 'Wait for tasks to finish'
   include_tasks: wait.yml
-  when: build_package_normal_execution_check is not defined
-  tags:
-    - wait
+  when: build_package_wait|bool
 
 - name: 'Download task results'
   include_tasks: download.yml
-  when: build_package_normal_execution_check is not defined
-  tags:
-    - wait
-    - download
+  when: build_package_download_logs|bool

--- a/obal/data/roles/build_package/tasks/main.yml
+++ b/obal/data/roles/build_package/tasks/main.yml
@@ -1,13 +1,3 @@
 ---
-# we use this to ensure that `wait` tagged tasks only run with `--tags
-# wait` is passed
-- name: 'Ensure wait tags run'
-  command: warn=no /bin/true
-  register: build_package_normal_execution_check
-  tags:
-    - skip_ansible_lint
-
 - name: "Include {{ build_package_build_system }}.yml"
   include_tasks: "{{ build_package_build_system }}.yml"
-  tags:
-    - always

--- a/obal/data/roles/build_package/tasks/tito_release.yml
+++ b/obal/data/roles/build_package/tasks/tito_release.yml
@@ -5,17 +5,11 @@
     chdir: "{{ inventory_dir }}/{{ package_base_dir }}/{{ inventory_hostname }}"
   register: build_package_tito_release
   when: build_package_tito_release is not defined
-  tags:
-    - always
 
 - debug:
     msg: "{{ build_package_tito_release.stdout_lines }}"
   when: build_package_tito_release | succeeded
-  tags:
-    - always
 
 - debug:
     msg: "{{ build_package_tito_release.stderr.split('\n') }}"
   when: build_package_tito_release | failed
-  tags:
-    - always

--- a/obal/data/roles/build_package/tasks/wait.yml
+++ b/obal/data/roles/build_package/tasks/wait.yml
@@ -6,23 +6,17 @@
           | select('match', '^Created task:.*') \
           | map('regex_replace', '^Created task:\\s(\\d+)', '\\1') \
           | list }}"
-      tags:
-        - always
 
     - name: "Watch {{ build_package_koji_command }} task(s)"
       command: "{{ build_package_koji_command }} watch-task {{ build_package_koji_tasks | join(' ') }}"
       ignore_errors: yes
       register: build_package_koji_status
       when: (build_package_tito_release | succeeded)
-      tags:
-        - always
 
     - name: 'Failed build'
       fail:
         msg: "The build in {{ build_package_koji_command }}  has failed"
       when: (build_package_koji_status | failed)
-      tags:
-        - always
   when: build_package_build_system == 'koji'
 
 - block:
@@ -32,21 +26,15 @@
           | select('match', '^Created builds:.*') \
           | map('regex_replace', '^Created builds:\\s(\\d+)', '\\1') \
           | list }}"
-      tags:
-        - always
 
     - name: "Watch copr task(s)"
       command: "copr-cli watch-build {{ build_package_copr_tasks | join(' ') }}"
       ignore_errors: yes
       register: build_package_copr_status
       when: (build_package_tito_release | succeeded)
-      tags:
-        - always
 
     - name: 'Failed build'
       fail:
         msg: "The build in Copr  has failed"
       when: (build_package_copr_status | failed)
-      tags:
-        - always
   when: build_package_build_system == 'copr'

--- a/obal/data/roles/diff_package/tasks/brew.yml
+++ b/obal/data/roles/diff_package/tasks/brew.yml
@@ -1,25 +1,17 @@
 ---
 - include_tasks: git_package_info.yml
-  tags:
-    - always
 
 - set_fact:
     diff_package_changed: False
-  tags:
-    - always
 
 - name: 'Look up current version of package in brew'
   shell: "brew list-tagged --quiet --latest {{ item }} {{ inventory_hostname }} | cut -d' ' -f1"
   register: brew_package_versions
-  tags:
-    - always
   with_items: "{{ brew_tags }}"
 
 - set_fact:
     diff_package_changed: "{{ not item.stdout.startswith(git_package_version) or diff_package_changed }}"
   with_items: "{{  brew_package_versions.results }}"
-  tags:
-    - always
 
 - debug:
     msg:
@@ -27,5 +19,3 @@
       - "Brew version: {{ item.stdout }}"
       - "Changed: {{ diff_package_changed }}"
   with_items: "{{ brew_package_versions.results }}"
-  tags:
-    - always

--- a/obal/data/roles/diff_package/tasks/copr.yml
+++ b/obal/data/roles/diff_package/tasks/copr.yml
@@ -1,7 +1,5 @@
 ---
 - include_tasks: git_package_info.yml
-  tags:
-    - always
 
 - name: 'Get latest package info from copr'
   command: >
@@ -12,36 +10,24 @@
       --with-latest-build
   register: copr_package_info
   ignore_errors: true
-  tags:
-    - always
 
 - set_fact:
     copr_package_info: "{{ copr_package_info.stdout | from_json }}"
   when: copr_package_info | success
-  tags:
-    - always
 
 - set_fact:
     copr_package_version: "{{ copr_package_info['name'] + '-' + copr_package_info['latest_build']['pkg_version'] }}"
   when: copr_package_info | success
-  tags:
-    - always
 
 - set_fact:
     copr_package_version: ""
   when: copr_package_info | failed
-  tags:
-    - always
 
 - set_fact:
     diff_package_changed: "{{ not copr_package_version.startswith(git_package_version) }}"
-  tags:
-    - always
 
 - debug:
     msg:
       - "Git version: {{ git_package_version }}"
       - "Copr version: {{ copr_package_version }}"
       - "Changed: {{ diff_package_changed }}"
-  tags:
-    - always

--- a/obal/data/roles/diff_package/tasks/git_package_info.yml
+++ b/obal/data/roles/diff_package/tasks/git_package_info.yml
@@ -4,14 +4,10 @@
     pattern: "*.spec"
     path: "{{ inventory_dir }}/packages/{{ inventory_hostname }}"
   register: spec_file
-  tags:
-    - always
 
 - name: "Set spec file path, scl options and releasers"
   set_fact:
     spec_file_path: "{{ spec_file.files[0].path }}"
-  tags:
-    - always
 
 - name: 'Get latest package info from git'
   command: >
@@ -22,10 +18,6 @@
       --srpm
       {{ spec_file_path }}
   register: git_package_info
-  tags:
-    - always
 
 - set_fact:
     git_package_version: "{{ git_package_info.stdout }}"
-  tags:
-    - always

--- a/obal/data/roles/diff_package/tasks/main.yml
+++ b/obal/data/roles/diff_package/tasks/main.yml
@@ -1,13 +1,9 @@
 ---
 - name: 'Include {{ diff_package_type }} package diff'
   include_tasks: "{{ diff_package_type }}.yml"
-  tags:
-    - always
   when: not diff_package_skip
 
 - name: 'Set diff_package_changed to True when skipping package diffs'
   set_fact:
     diff_package_changed: True
   when: diff_package_skip
-  tags:
-    - always

--- a/obal/data/roles/ensure_package/tasks/main.yml
+++ b/obal/data/roles/ensure_package/tasks/main.yml
@@ -4,5 +4,3 @@
     path: "{{ inventory_dir }}/{{ package_base_dir }}/{{ inventory_hostname }}"
   register: package_dir
   failed_when: not package_dir.stat.exists
-  tags:
-    - always

--- a/obal/data/roles/git_annex_setup/tasks/main.yml
+++ b/obal/data/roles/git_annex_setup/tasks/main.yml
@@ -4,5 +4,3 @@
   args:
     creates: .git/annex/index
     chdir: "{{ inventory_dir }}"
-  tags:
-    - always

--- a/obal/data/roles/setup_sources/tasks/annex.yml
+++ b/obal/data/roles/setup_sources/tasks/annex.yml
@@ -3,21 +3,15 @@
   set_fact:
     setup_sources_source: "{{ item }}"
     setup_sources_sourcebase: "{{ item | basename }}"
-  tags:
-    - always
 
 - name: 'Set source path'
   set_fact:
     setup_sources_sourcepath: "{{ package_dir  }}/{{ setup_sources_sourcebase }}"
-  tags:
-    - always
 
 - name: 'Source exists'
   stat:
     path: "{{ setup_sources_sourcepath }}"
   register: setup_sources_source_exists
-  tags:
-    - always
 
 - name: 'Search annex for web link'
   shell: 'git annex whereis {{ setup_sources_sourcepath }} 2>/dev/null | grep -q " web:"'
@@ -27,8 +21,6 @@
   register: setup_sources_search_annex
   ignore_errors: yes
   when: (not setup_sources_source_exists.stat.exists) or ( setup_sources_source_exists.stat.exists and setup_sources_source_exists.stat.islnk is defined and setup_sources_source_exists.stat.islnk )
-  tags:
-    - always
 
 - name: 'Add url to annex for source'
   command: "git annex addurl {{ setup_sources_annex_options }} --file '{{ setup_sources_sourcebase }}' '{{ setup_sources_source }}'"
@@ -36,5 +28,3 @@
     chdir: "{{ package_dir }}"
   ignore_errors: yes
   when: setup_sources_search_annex|failed
-  tags:
-    - always

--- a/obal/data/roles/setup_sources/tasks/git.yml
+++ b/obal/data/roles/setup_sources/tasks/git.yml
@@ -13,5 +13,3 @@
 - name: 'Register source dir tito argument'
   set_fact:
     build_package_tito_releaser_args: '--arg source_dir={{ setup_sources_git_checkout_dir }}'
-  tags:
-    - always

--- a/obal/data/roles/setup_sources/tasks/main.yml
+++ b/obal/data/roles/setup_sources/tasks/main.yml
@@ -2,17 +2,11 @@
 - name: 'Set package_dir'
   set_fact:
     package_dir: "{{ inventory_dir }}/{{ package_base_dir }}/{{ inventory_hostname }}"
-  tags:
-    - always
 
 - name: 'Setup sources from specfile'
   include_tasks: specfile.yml
   when: setup_sources_git is not defined
-  tags:
-    - always
 
 - name: 'Clone git repository'
   include_tasks: git.yml
   when: setup_sources_git is defined
-  tags:
-    - always

--- a/obal/data/roles/setup_sources/tasks/specfile.yml
+++ b/obal/data/roles/setup_sources/tasks/specfile.yml
@@ -4,23 +4,15 @@
     pattern: "*.spec"
     path: "{{ package_dir }}"
   register: setup_sources_spec_file
-  tags:
-    - always
 
 - name: 'Set spec file path'
   set_fact:
     setup_sources_spec_file_path: "{{ setup_sources_spec_file.files[0].path }}"
-  tags:
-    - always
 
 - name: 'Extract Sources from spec'
   shell: "spectool --list-files --sources {{ setup_sources_spec_file_path }} | awk '{print $2}'"
   register: setup_sources_sources
   changed_when: False
-  tags:
-    - always
 
 - include_tasks: annex.yml
   with_items: "{{ setup_sources_sources.stdout_lines | list }}"
-  tags:
-    - always


### PR DESCRIPTION
instead use two boolean vars to tell the build_package role whether it should wait and download logs.

also changes the default to wait, users can opt out by passing `-e build_package_wait=False`

Closes: #65