### PR TITLE
make build_package depend on setup_sources

### DIFF
--- a/obal/data/release_package.yml
+++ b/obal/data/release_package.yml
@@ -5,7 +5,6 @@
   roles:
     - git_annex_setup
     - ensure_package
-    - setup_sources
     - diff_package
     - role: build_package
       when: diff_package_changed

--- a/obal/data/roles/build_package/meta/main.yml
+++ b/obal/data/roles/build_package/meta/main.yml
@@ -1,3 +1,4 @@
 ---
 dependencies:
+  - { role: setup_sources }
   - { role: package_variables }

--- a/obal/data/scratch_build.yml
+++ b/obal/data/scratch_build.yml
@@ -8,6 +8,5 @@
     build_package_test: true
   roles:
     - git_annex_setup
-    - setup_sources
     - ensure_package
     - build_package


### PR DESCRIPTION
instead of calling it directly in the playbooks