### PR TITLE
Properly set the defaults for scratch_build

### DIFF
--- a/obal/data/roles/build_package/tasks/koji.yml
+++ b/obal/data/roles/build_package/tasks/koji.yml
@@ -12,12 +12,12 @@
 - name: 'Set test build'
   set_fact:
       build_package_tito_args: "{{ build_package_tito_args }} --test"
-  when: build_package_test|default(false)
+  when: build_package_test|default(true)
 
 - name: 'Set scratch build'
   set_fact:
     build_package_tito_args: "{{ build_package_tito_args }} --scratch"
-  when: build_package_koji_command != 'brew' and build_package_scratch|default(false)
+  when: build_package_koji_command != 'brew' and build_package_scratch|default(true)
 
 - include_tasks: tito_release.yml
 

--- a/obal/data/scratch_build.yml
+++ b/obal/data/scratch_build.yml
@@ -3,8 +3,5 @@
   serial: 1
   any_errors_fatal: false # don't bomb out the entire playbook if one host (i.e. package) fails
   gather_facts: no
-  vars:
-    build_package_scratch: true
-    build_package_test: true
   roles:
     - build_package


### PR DESCRIPTION
The old way didn't allow overriding in package_manifest.yml