### PR TITLE
Do not use --test by default in scratch_build

### DIFF
--- a/obal/data/scratch_build.yml
+++ b/obal/data/scratch_build.yml
@@ -5,6 +5,5 @@
   gather_facts: no
   vars:
     build_package_scratch: true
-    build_package_test: true
   roles:
     - build_package

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -97,7 +97,7 @@ def test_obal_scratch_upstream_hello():
     assert os.path.exists('packages/hello/hello-2.10.tar.gz')
 
     expected_log = [
-        "['{bin}/tito', 'release', '--test', '--scratch', 'dist-git', '-y']",
+        "['{bin}/tito', 'release', '--scratch', 'dist-git', '-y']",
         "['{bin}/koji', 'watch-task']"
     ]
     assert_mockbin_log(expected_log)
@@ -110,7 +110,7 @@ def test_obal_scratch_upstream_hello_nowait():
     assert os.path.exists('packages/hello/hello-2.10.tar.gz')
 
     expected_log = [
-        "['{bin}/tito', 'release', '--test', '--scratch', 'dist-git', '-y']"
+        "['{bin}/tito', 'release', '--scratch', 'dist-git', '-y']"
     ]
     assert_mockbin_log(expected_log)
 
@@ -149,7 +149,7 @@ def test_obal_scratch_downstream_hello_nowait():
     assert os.path.exists('packages/hello/hello-2.9.tar.gz')
 
     expected_log = [
-        "['{bin}/tito', 'release', '--test', 'obaltest-scratch-rhel-7', '-y']"
+        "['{bin}/tito', 'release', 'obaltest-scratch-rhel-7', '-y']"
     ]
     assert_mockbin_log(expected_log)
 
@@ -174,7 +174,7 @@ def test_obal_scratch_downstream_hello():
     assert os.path.exists('packages/hello/hello-2.9.tar.gz')
 
     expected_log = [
-        "['{bin}/tito', 'release', '--test', 'obaltest-scratch-rhel-7', '-y']",
+        "['{bin}/tito', 'release', 'obaltest-scratch-rhel-7', '-y']",
         "['{bin}/brew', 'watch-task']",
     ]
     assert_mockbin_log(expected_log)
@@ -187,7 +187,7 @@ def test_obal_scratch_downstream_hello_wait_download():
     assert os.path.exists('packages/hello/hello-2.9.tar.gz')
 
     expected_log = [
-        "['{bin}/tito', 'release', '--test', 'obaltest-scratch-rhel-7', '-y']",
+        "['{bin}/tito', 'release', 'obaltest-scratch-rhel-7', '-y']",
         "['{bin}/brew', 'watch-task']",
         "['{bin}/brew', 'download-logs', '-r']",
     ]


### PR DESCRIPTION
Some packages can't build with this and because playbooks take
precedence over host variables, it can't be overridden.