### PR TITLE
speed up git clones by creating shallow clones with depth 1

### DIFF
--- a/obal/data/roles/fetch_sources/tasks/main.yml
+++ b/obal/data/roles/fetch_sources/tasks/main.yml
@@ -10,6 +10,7 @@
         dest: "{{ obal_tmp_dir }}/{{ upstream_directory }}"
         version: "{{ branch }}"
         update: yes
+        depth: 1
 
     - name: 'Copy upstream files'
       synchronize:

--- a/obal/data/roles/setup_sources/tasks/git.yml
+++ b/obal/data/roles/setup_sources/tasks/git.yml
@@ -9,6 +9,7 @@
     dest: "{{ setup_sources_git_checkout_dir }}"
     version: "{{ git_branch|default('master') }}"
     force: yes
+    depth: 1
 
 - name: 'Register source dir tito argument'
   set_fact:

--- a/tests/fixtures/testrepo/downstream/package_manifest.yaml
+++ b/tests/fixtures/testrepo/downstream/package_manifest.yaml
@@ -13,7 +13,7 @@ packages:
       - obaltest-6.3.0-rhel-7-candidate
   hosts:
     hello:
-      upstream: "../../upstream/.git"
+      upstream: "file://{{ inventory_dir }}/../upstream/.git"
       branch: "master"
       upstream_files:
         - "packages/hello/"

--- a/tests/fixtures/testrepo/empty/package_manifest.yaml
+++ b/tests/fixtures/testrepo/empty/package_manifest.yaml
@@ -7,7 +7,7 @@ packages:
       - obaltest-dist-git-rhel-7
   hosts:
     hello:
-      upstream: "../../upstream/.git"
+      upstream: "file://{{ inventory_dir }}/../upstream/.git"
       branch: "master"
       upstream_files:
         - "packages/hello/"


### PR DESCRIPTION
this speeds up `setup_sources` for `foreman-packaging` from 600 to 12 seconds for me.