### PR TITLE
Set the long description content type to markdown

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
     version='0.0.3',
     description='packaging wrapper using ansible',
     long_description=long_description,
+    long_description_content_type='text/markdown',
     url='https://github.com/theforeman/obal',
     author='The Foreman Project',
     author_email='foreman-dev@googlegroups.com',


### PR DESCRIPTION
See https://dustingram.com/articles/2018/03/16/markdown-descriptions-on-pypi for more information.