### PR TITLE
[RFC] Add help texts to playbooks

### DIFF
--- a/obal/__init__.py
+++ b/obal/__init__.py
@@ -6,11 +6,11 @@ from __future__ import print_function
 import argparse
 import errno
 import glob
+import json
 import os
 import sys
 
 import yaml
-
 from pkg_resources import resource_filename
 
 try:
@@ -19,30 +19,69 @@ except ImportError:
     argcomplete = None
 
 
+class VariableAction(argparse.Action):
+    def __call__(self, parser, namespace, values, option_string=None):
+        variables = getattr(namespace, self.dest)
+        if variables is None:
+            variables = {}
+            setattr(namespace, self.dest, variables)
+
+        if not option_string:
+            # TODO: Can we still know this?
+            raise ValueError('Unknown option')
+        if option_string.startswith('--'):
+            option_string = option_string[2:]
+        variables[option_string] = values
+
+
+class Playbook(object):
+    def __init__(self, path):
+        self.path = path
+
+        filename = os.path.basename(path)
+        self.name = os.path.splitext(filename)[0]
+
+        self._metadata = None
+
+    @property
+    def _metadata_path(self):
+        return os.path.join(os.path.dirname(self.path), '{}.obal.yaml'.format(self.name))
+
+    @property
+    def metadata(self):
+        if not self._metadata:
+            metadata = {
+                'help': '',
+                'vars': {},
+            }
+
+            try:
+                with open(self._metadata_path) as obal_metadata:
+                    metadata.update(yaml.load(obal_metadata))
+            # Python 3 has FileNotFoundError, Python 2 doesn't
+            except IOError as error:
+                if error.errno != errno.ENOENT:
+                    raise
+
+            self._metadata = metadata
+
+        return self._metadata
+
+    @property
+    def playbook_variables(self):
+        return self.metadata['vars']
+
+    @property
+    def __doc__(self):
+        return self.metadata['help']
+
+
 def find_playbooks(playbooks_path):
-    playbooks = glob.glob(os.path.join(playbooks_path, '*.yml'))
-    playbooks_actions = {}
-    for playbook in playbooks:
-        filename = os.path.basename(playbook)
-        action = os.path.splitext(filename)[0]
-
-        metadata = {
-            'help': '',
-            'vars': {},
-        }
-        try:
-            with open(os.path.join(playbooks_path, '{}.obal.yaml'.format(action))) as obal_metadata:
-                metadata.update(yaml.load(obal_metadata))
-        # Python 3 has FileNotFoundError, Python 2 doesn't
-        except IOError as error:
-            if error.errno != errno.ENOENT:
-                raise
-
-        playbooks_actions[action] = {
-            'playbook': playbook,
-            'metadata': metadata,
-        }
-    return playbooks_actions
+    playbooks = {}
+    for playbook_path in glob.glob(os.path.join(playbooks_path, '*.yml')):
+        playbook = Playbook(playbook_path)
+        playbooks[playbook.name] = playbook
+    return playbooks
 
 
 def find_packages(inventory_path):
@@ -98,19 +137,20 @@ def obal_argument_parser(actions, package_choices):
     # though it's in the docs).
     subparsers.required = True
 
-    for name, action in actions.items():
-        action_subparser = subparsers.add_parser(name, parents=[parent_parser],
-                                                 help=action['metadata']['help'])
-        if name != 'setup':
+    for action in actions:
+        action_subparser = subparsers.add_parser(action.name, parents=[parent_parser],
+                                                 help=action.__doc__)
+        if action.name != 'setup':
             action_subparser.add_argument('package',
                                           metavar='package',
                                           choices=package_choices,
                                           nargs='+',
                                           help="the package to build")
 
-        for var_name, var_help in action['metadata']['vars'].items():
+        for var_name, var_help in action.playbook_variables.items():
             # TODO: expose more than just help?
-            action_subparser.add_argument('--arg-{}'.format(var_name), help=var_help)
+            action_subparser.add_argument('--{}'.format(var_name), help=var_help, dest='variables',
+                                          action=VariableAction)
 
     if argcomplete:
         argcomplete.autocomplete(parser)
@@ -127,9 +167,8 @@ def generate_ansible_args(inventory_path, playbook_path, args):
         ansible_args.append("-%s" % str("v" * args.verbose))
     for extra_var in args.extra_vars:
         ansible_args.extend(["-e", extra_var])
-    for key, value in vars(args).items():
-        if key.startswith('arg_') and value:
-            ansible_args.extend(["-e", "{}={}".format(key[4:], value)])
+    if args.variables:
+        ansible_args.extend(["-e", json.dumps(args.variables)])
     if args.tags:
         ansible_args.append("--tags")
         ansible_args.append(",".join(args.tags))
@@ -160,11 +199,11 @@ def main(cliargs=None):
     package_choices = find_packages(inventory_path)
     playbooks = find_playbooks(packaging_playbooks_path)
 
-    parser = obal_argument_parser(playbooks, package_choices)
+    parser = obal_argument_parser(playbooks.values(), package_choices)
 
     args = parser.parse_args(cliargs)
 
-    playbook_path = playbooks[args.action]['playbook']
+    playbook_path = playbooks[args.action].path
 
     if not args.action == 'setup':
         if not os.path.exists(inventory_path):

--- a/obal/data/playbooks/changelog.obal.yaml
+++ b/obal/data/playbooks/changelog.obal.yaml
@@ -1,0 +1,4 @@
+help: >
+  The changelog command writes a RPM changelog entry for the current version and release.
+vars:
+  changelog: The text for the changelog entry


### PR DESCRIPTION
This introduces an obal metadata file that describes a playbook.  Currently it can store a help text and a hash of variables. Those will get translated into command line arguments with a help text.

Do we want to to expose more parameters of add_argument?

There are some subtleties in doing that, like not copying defaults. Currently they are only passed in if they are non-empty which means you can't override defaults with an empty value. They are also prefixed with --arg so they don't conflict with the other options but that may be overkill. It does make handling very easy.

This PR now has a metadata example for changelog. This will be rendered as follows:

```
$ obal --help
usage: obal [-h]
            {bump-release,changelog,scratch,setup,lint,update,nightly,repoclosure,add,source,release,cleanup-copr,srpm,check}
            ...

positional arguments:
  {bump-release,changelog,scratch,setup,lint,update,nightly,repoclosure,add,source,release,cleanup-copr,srpm,check}
                        which action to execute
    bump-release
    changelog           The changelog command writes a RPM changelog entry for
                        the current version and release.
    scratch
    setup
    lint
    update
    nightly
    repoclosure
    add
    source
    release
    cleanup-copr
    srpm
    check

optional arguments:
  -h, --help            show this help message and exit
```

```
$ obal changelog --help
usage: obal changelog [-h] [-e EXTRA_VARS] [-v] [--step] [-t TAGS]
                      [--skip-tags SKIP_TAGS] [--arg-changelog ARG_CHANGELOG]
                      package [package ...]

positional arguments:
  package               the package to build

optional arguments:
  -h, --help            show this help message and exit
  -e EXTRA_VARS, --extra-vars EXTRA_VARS
                        set additional variables as key=value or YAML/JSON, if
                        filename prepend with @
  -v, --verbose         verbose output
  --step                interactive: confirm each task before running
  -t TAGS, --tags TAGS  only run plays and tasks tagged with these values
  --skip-tags SKIP_TAGS
                        only run plays and tasks whose tags do not match these
                        values
  --arg-changelog ARG_CHANGELOG
                        The text for the changelog entry
```