### PR TITLE
Automatically determine if a playbook takes packages

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,2 +1,4 @@
 [MASTER]
 ignore=tests
+# Disable useless-object-inheritance because we still support py2
+disable=R0205

--- a/obal/__init__.py
+++ b/obal/__init__.py
@@ -24,6 +24,27 @@ except ImportError:
 display = None  # pylint: disable=C0103
 
 
+def _get_data_path():
+    """
+    Return the data path. Houses playbooks and configs.
+    """
+    return resource_filename(__name__, 'data')
+
+
+def get_playbooks_path():
+    """
+    Return the default playbooks path
+    """
+    return os.path.join(_get_data_path(), 'playbooks')
+
+
+def get_ansible_config_path():
+    """
+    Return the default playbooks path
+    """
+    return os.path.join(_get_data_path(), 'ansible.cfg')
+
+
 def find_playbooks(playbooks_path):
     """
     Find all playbooks in the given path.
@@ -140,9 +161,7 @@ def main(cliargs=None):  # pylint: disable=R0914
     """
     Main command
     """
-    data_path = resource_filename(__name__, 'data')
-    packaging_playbooks_path = os.path.join(data_path, 'playbooks')
-    cfg_path = os.path.join(data_path, 'ansible.cfg')
+    cfg_path = get_ansible_config_path()
 
     if os.path.exists(cfg_path):
         os.environ["ANSIBLE_CONFIG"] = cfg_path
@@ -156,7 +175,7 @@ def main(cliargs=None):  # pylint: disable=R0914
     inventory_path = os.path.join(os.getcwd(), 'package_manifest.yaml')
 
     package_choices = find_packages(inventory_path)
-    playbooks = find_playbooks(packaging_playbooks_path)
+    playbooks = find_playbooks(get_playbooks_path())
 
     parser = obal_argument_parser(playbooks.keys(), package_choices)
 

--- a/obal/__init__.py
+++ b/obal/__init__.py
@@ -12,6 +12,7 @@ import glob
 import os
 import sys
 
+import yaml
 from pkg_resources import resource_filename
 
 try:
@@ -41,8 +42,10 @@ class Playbook(object):  # pylint: disable=R0903
 
         This is determined by a hosts: packages inside the playbook
         """
-        # TODO: Read this from the playbook itself?
-        return self.name != 'setup'
+        with open(self.path) as playbook_file:
+            plays = yaml.load(playbook_file.read())
+
+        return any('packages' in play['hosts'] for play in plays)
 
     def __str__(self):
         return self.name

--- a/obal/data/playbooks/add.yml
+++ b/obal/data/playbooks/add.yml
@@ -1,5 +1,6 @@
 ---
-- hosts: packages
+- hosts:
+    - packages
   serial: 1
   gather_facts: no
 

--- a/obal/data/playbooks/bump-release.yml
+++ b/obal/data/playbooks/bump-release.yml
@@ -1,5 +1,6 @@
 ---
-- hosts: packages
+- hosts:
+    - packages
   serial: 1
   gather_facts: no
   vars:

--- a/obal/data/playbooks/changelog.yml
+++ b/obal/data/playbooks/changelog.yml
@@ -1,5 +1,6 @@
 ---
-- hosts: packages
+- hosts:
+    - packages
   serial: 1
   gather_facts: no
   roles:

--- a/obal/data/playbooks/check.yml
+++ b/obal/data/playbooks/check.yml
@@ -1,5 +1,6 @@
 ---
-- hosts: packages
+- hosts:
+    - packages
   serial: 1
   gather_facts: no
   roles:

--- a/obal/data/playbooks/cleanup-copr.yml
+++ b/obal/data/playbooks/cleanup-copr.yml
@@ -1,5 +1,6 @@
 ---
-- hosts: localhost
+- hosts:
+    - localhost
   gather_facts: no
   tasks:
     - name: 'Get Copr repositories'

--- a/obal/data/playbooks/lint.yml
+++ b/obal/data/playbooks/lint.yml
@@ -1,5 +1,6 @@
 ---
-- hosts: packages
+- hosts:
+    - packages
   serial: 1
   gather_facts: no
   roles:

--- a/obal/data/playbooks/nightly.yml
+++ b/obal/data/playbooks/nightly.yml
@@ -1,5 +1,6 @@
 ---
-- hosts: packages
+- hosts:
+    - packages
   serial: 1
   gather_facts: no
   roles:

--- a/obal/data/playbooks/release.yml
+++ b/obal/data/playbooks/release.yml
@@ -1,5 +1,6 @@
 ---
-- hosts: packages
+- hosts:
+    - packages
   serial: 1
   gather_facts: no
   roles:

--- a/obal/data/playbooks/repoclosure.yml
+++ b/obal/data/playbooks/repoclosure.yml
@@ -1,4 +1,6 @@
-- hosts: repoclosures packages
+- hosts:
+    - repoclosures
+    - packages
   gather_facts: no
   roles:
     - repoclosure

--- a/obal/data/playbooks/scratch.yml
+++ b/obal/data/playbooks/scratch.yml
@@ -1,5 +1,6 @@
 ---
-- hosts: packages
+- hosts:
+    - packages
   serial: 1
   any_errors_fatal: false # don't bomb out the entire playbook if one host (i.e. package) fails
   gather_facts: no

--- a/obal/data/playbooks/setup.yml
+++ b/obal/data/playbooks/setup.yml
@@ -1,5 +1,6 @@
 ---
-- hosts: localhost
+- hosts:
+    - localhost
   connection: local
   gather_facts: no
   tasks:

--- a/obal/data/playbooks/source.yml
+++ b/obal/data/playbooks/source.yml
@@ -1,5 +1,6 @@
 ---
-- hosts: packages
+- hosts:
+    - packages
   serial: 1
   gather_facts: no
   roles:

--- a/obal/data/playbooks/srpm.yml
+++ b/obal/data/playbooks/srpm.yml
@@ -1,5 +1,6 @@
 ---
-- hosts: packages
+- hosts:
+    - packages
   serial: 1
   gather_facts: no
   roles:

--- a/obal/data/playbooks/update.yml
+++ b/obal/data/playbooks/update.yml
@@ -1,5 +1,6 @@
 ---
-- hosts: packages
+- hosts:
+    - packages
   serial: 1
   gather_facts: no
   roles:

--- a/rules/PlayHostsIsList.py
+++ b/rules/PlayHostsIsList.py
@@ -1,0 +1,30 @@
+# pylint: disable=C0103,C0111,R0903
+
+from ansiblelint import AnsibleLintRule
+
+
+try:
+    basestring
+except NameError:  # Python 3 has no basestring
+    basestring = str  # pylint: disable=W0622
+
+
+def _is_invalid_hosts(hosts):
+    try:
+        iter(hosts)
+    except TypeError:
+        return True
+
+    return isinstance(hosts, basestring)
+
+
+class PlayHostsIsList(AnsibleLintRule):
+    id = 'E306'
+    shortdesc = 'Hosts in a play must be a list'
+    description = ''
+    tags = ['play']
+
+    def matchplay(self, file, data):  # pylint: disable=W0622
+        if file['type'] == 'playbook' and 'hosts' in data and _is_invalid_hosts(data['hosts']):
+            return ({'hosts': data}, self.shortdesc)
+        return None

--- a/tests/fixtures/playbooks/dummy.yml
+++ b/tests/fixtures/playbooks/dummy.yml
@@ -1,2 +1,3 @@
 ---
-- hosts: packages
+- hosts:
+    - packages

--- a/tests/fixtures/playbooks/dummy.yml
+++ b/tests/fixtures/playbooks/dummy.yml
@@ -1,0 +1,2 @@
+---
+- hosts: packages

--- a/tests/fixtures/playbooks/multiple_plays.yml
+++ b/tests/fixtures/playbooks/multiple_plays.yml
@@ -1,0 +1,10 @@
+---
+- hosts:
+    - localhost
+  roles:
+    - setup
+
+- hosts:
+    - packages
+  roles:
+    - diff_package

--- a/tests/fixtures/playbooks/repoclosure.yml
+++ b/tests/fixtures/playbooks/repoclosure.yml
@@ -1,0 +1,6 @@
+---
+- hosts:
+    - repoclosure
+    - packages
+  roles:
+    - repoclosure

--- a/tests/fixtures/playbooks/setup.yml
+++ b/tests/fixtures/playbooks/setup.yml
@@ -1,0 +1,2 @@
+---
+- hosts: localhost

--- a/tests/fixtures/playbooks/setup.yml
+++ b/tests/fixtures/playbooks/setup.yml
@@ -1,2 +1,3 @@
 ---
-- hosts: localhost
+- hosts:
+    - localhost

--- a/tests/test_obal.py
+++ b/tests/test_obal.py
@@ -1,7 +1,6 @@
 import os
 import pytest
 import obal
-from pkg_resources import resource_filename
 
 
 FIXTURE_DIR = os.path.join(
@@ -9,7 +8,8 @@ FIXTURE_DIR = os.path.join(
     'fixtures',
 )
 
-DEFAULT_ARGS = ['dummy.yml', '--inventory', 'inventory.yml']
+DEFAULT_ARGS = [os.path.join(FIXTURE_DIR, 'playbooks', 'dummy.yml'),
+                '--inventory', 'inventory.yml']
 
 
 def test_find_no_packages():
@@ -23,13 +23,18 @@ def test_find_packages():
     assert 'testpackage' in packages
 
 
+def test_playbook_constructor():
+    path = os.path.join(FIXTURE_DIR, 'playbooks', 'setup.yml')
+    playbook = obal.Playbook(path)
+    assert playbook.path == path
+    assert playbook.name == 'setup'
+
+
 def _test_generate_ansible_args(cliargs):
-    playbooks_path = resource_filename('obal', 'data/playbooks')
-    playbooks = obal.find_playbooks(playbooks_path)
-    parser = obal.obal_argument_parser(playbooks.keys(), ['testpackage'])
+    playbooks = obal.find_playbooks(os.path.join(FIXTURE_DIR, 'playbooks'))
+    parser = obal.obal_argument_parser(playbooks, ['testpackage'])
     args = parser.parse_args(cliargs)
-    ansible_args = obal.generate_ansible_args('inventory.yml', 'dummy.yml',
-                                              args)
+    ansible_args = obal.generate_ansible_args('inventory.yml', args)
     return ansible_args
 
 
@@ -39,19 +44,21 @@ def test_generate_ansible_args_none():
 
 
 @pytest.mark.parametrize('cliargs,expected', [
-    (['scratch', 'testpackage'],
+    (['setup'],
+     [os.path.join(FIXTURE_DIR, 'playbooks', 'setup.yml'), '--inventory', 'inventory.yml']),
+    (['dummy', 'testpackage'],
      DEFAULT_ARGS + ['--limit', 'testpackage']),
-    (['scratch', 'testpackage', '--verbose'],
+    (['dummy', 'testpackage', '--verbose'],
      DEFAULT_ARGS + ['--limit', 'testpackage', '-v']),
-    (['scratch', 'testpackage', '-vvvv'],
+    (['dummy', 'testpackage', '-vvvv'],
      DEFAULT_ARGS + ['--limit', 'testpackage', '-vvvv']),
-    (['scratch', 'testpackage', '--step'],
+    (['dummy', 'testpackage', '--step'],
      DEFAULT_ARGS + ['--limit', 'testpackage', '--step']),
-    (['scratch', 'testpackage', '--skip-tags', 't1,t2'],
+    (['dummy', 'testpackage', '--skip-tags', 't1,t2'],
      DEFAULT_ARGS + ['--limit', 'testpackage', '--skip-tags', 't1,t2']),
-    (['scratch', 'testpackage', '--tags', 'wait,download'],
+    (['dummy', 'testpackage', '--tags', 'wait,download'],
      DEFAULT_ARGS + ['--limit', 'testpackage', '--tags', 'wait,download']),
-    (['scratch', 'testpackage', '-e', 'v1=1', '-e', 'v2=2'],
+    (['dummy', 'testpackage', '-e', 'v1=1', '-e', 'v2=2'],
      DEFAULT_ARGS + ['--limit', 'testpackage', '-e', 'v1=1', '-e', 'v2=2']),
 ])
 def test_generate_ansible_args(cliargs, expected):

--- a/tests/test_obal.py
+++ b/tests/test_obal.py
@@ -30,6 +30,17 @@ def test_playbook_constructor():
     assert playbook.name == 'setup'
 
 
+@pytest.mark.parametrize('playbook,expected', [
+    ('setup', False),
+    ('dummy', True),
+    ('multiple_plays', True),
+    ('repoclosure', True),
+])
+def test_playbook_takes_package_parameter(playbook, expected):
+    path = os.path.join(FIXTURE_DIR, 'playbooks', '{}.yml'.format(playbook))
+    assert obal.Playbook(path).takes_package_parameter == expected
+
+
 def _test_generate_ansible_args(cliargs):
     playbooks = obal.find_playbooks(os.path.join(FIXTURE_DIR, 'playbooks'))
     parser = obal.obal_argument_parser(playbooks, ['testpackage'])

--- a/tests/test_playbooks.py
+++ b/tests/test_playbooks.py
@@ -1,0 +1,23 @@
+import py.path
+import pytest
+
+import obal
+
+
+@pytest.fixture
+def help_dir():
+    return py.path.local(__file__).realpath() / '..' / 'fixtures' / 'help'
+
+
+def playbook_id(fixture_value):
+    return fixture_value.name
+
+
+@pytest.fixture(params=obal.find_playbooks(obal.get_playbooks_path()), ids=playbook_id)
+def playbook(request):
+    yield request.param
+
+
+def test_takes_package_argument(playbook):
+    expected = playbook.name != 'setup'
+    assert playbook.takes_package_parameter == expected

--- a/tests/test_playbooks.py
+++ b/tests/test_playbooks.py
@@ -19,5 +19,5 @@ def playbook(request):
 
 
 def test_takes_package_argument(playbook):
-    expected = playbook.name != 'setup'
+    expected = playbook.name not in ('setup', 'cleanup-copr')
     assert playbook.takes_package_parameter == expected


### PR DESCRIPTION
Note this changes the clean-copr action because it doesn't use packages. I think this is a good example where autodetection is better than explicit exceptions.