### PR TITLE
Remove downstream packages from setup

### DIFF
--- a/obal/data/playbooks/setup.yml
+++ b/obal/data/playbooks/setup.yml
@@ -12,11 +12,9 @@
       with_items:
         - rpm-build
         - koji
-        - brewkoji
         - git-annex
         - quvi
         - tito
-        - rhpkg
         - scl-utils
         - scl-utils-build
         - rpmlint


### PR DESCRIPTION
These only exist in downstream channels. That means running the setup only works in certain environments.