### PR TITLE
Fix test_obal_lint_hello_with_epoch test

### DIFF
--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -438,7 +438,7 @@ def test_obal_lint_hello():
 def test_obal_lint_hello_with_epoch():
     assert_obal_success(['lint', 'hello'])
 
-    assert_mockbin_log(["rpmlint {pwd}/packages/hello"])
+    assert_mockbin_log(["rpmlint --file {pwd}/packages/hello/.rpmlintrc {pwd}/packages/hello"])
 
 
 @obal_cli_test(repotype='upstream_bad_changelog')


### PR DESCRIPTION
e67af5b6da771388d77f40909dfb6b5e89e3535f was created before 3eb284f44b3f2f71aae28e61cfe5d83eeac28280 and merged with a rebase so the test was never run on this combination.