### PR TITLE
set nightly macro globaly via ansible

### DIFF
--- a/obal/data/playbooks/nightly/nightly.yaml
+++ b/obal/data/playbooks/nightly/nightly.yaml
@@ -5,14 +5,20 @@
   gather_facts: no
   vars:
     build_package_tito_releaser_args: "{{ nightly_package_tito_releaser_args | default([]) }}"
-  pre_tasks:
-    - name: 'set nightly_releaser'
-      set_fact:
-        releasers:
-          - "{{ nightly_releaser }}"
+  tasks:
+    - name: 'legacy nightly building'
+      block:
+        - name: 'set nightly_releaser'
+          set_fact:
+            releasers:
+              - "{{ nightly_releaser }}"
+
+        - import_role:
+            name: build_package
       when: nightly_releaser is defined and '--arg jenkins_job=' in (build_package_tito_releaser_args | join(' '))
 
-    - block:
+    - name: 'nightly building'
+      block:
         - name: 'set package_dir'
           set_fact:
             package_dir: "{{ inventory_dir }}/{{ package_base_dir }}/{{ inventory_hostname }}/"
@@ -44,21 +50,20 @@
             insertbefore: BOF
             backup: yes
           register: original_specfile
+
+        - import_role:
+            name: build_package
       when: nightly_sourcefiles is defined and nightly_githash is defined
-
-  roles:
-    - build_package
-
-  post_tasks:
-    - block:
+      always:
         - name: 'restore spec file'
           copy:
             src: "{{ original_specfile.backup }}"
             dest: "{{ nightly_specfile_path }}"
+          when: original_specfile is defined
 
         - name: 'delete copied source files'
           file:
             state: absent
             path: "{{ package_dir}}/{{ item | basename }}"
           with_items: "{{ nightly_sourcefiles }}"
-      when: nightly_sourcefiles is defined and nightly_githash is defined
+          when: nightly_sourcefiles is defined

--- a/obal/data/playbooks/nightly/nightly.yaml
+++ b/obal/data/playbooks/nightly/nightly.yaml
@@ -13,21 +13,52 @@
       when: nightly_releaser is defined and '--arg jenkins_job=' in (build_package_tito_releaser_args | join(' '))
 
     - block:
-      - name: 'set nightly_macro_args'
-        set_fact:
-          nightly_macro_args:
-            - "--arg rpmbuild_options=\"--define 'nightly .{{ lookup('pipe', 'date +%Y%m%d%H%M%S') }}git{{ nightly_githash[:7] }}'\""
+        - name: 'set package_dir'
+          set_fact:
+            package_dir: "{{ inventory_dir }}/{{ package_base_dir }}/{{ inventory_hostname }}/"
 
-      - name: 'append nightly_macro_args to build_package_tito_releaser_args'
-        set_fact:
-          build_package_tito_releaser_args: "{{ build_package_tito_releaser_args }} + {{ nightly_macro_args }}"
+        - name: 'set global_nightly_macro'
+          set_fact:
+            global_nightly_macro: "%global nightly .{{ lookup('pipe', 'date +%Y%m%d%H%M%S') }}git{{ nightly_githash[:7] }}"
 
-      - name: copy source files
-        copy:
-          src: "{{ item }}"
-          dest: "{{ inventory_dir }}/{{ package_base_dir }}/{{ inventory_hostname }}/"
-        with_items: "{{ nightly_sourcefiles }}"
+        - name: 'copy source files'
+          copy:
+            src: "{{ item }}"
+            dest: "{{ package_dir }}"
+          with_items: "{{ nightly_sourcefiles }}"
+
+        - name: 'get nightly_specfile'
+          find:
+            pattern: "*.spec"
+            path: "{{ package_dir }}"
+          register: nightly_specfile
+
+        - name: 'set nightly_specfile_path'
+          set_fact:
+            nightly_specfile_path: "{{ nightly_specfile.files[0].path }}"
+
+        - name: 'add nightly macro to specfile'
+          lineinfile:
+            path: "{{ nightly_specfile_path }}"
+            line: "{{ global_nightly_macro }}"
+            insertbefore: BOF
+            backup: yes
+          register: original_specfile
       when: nightly_sourcefiles is defined and nightly_githash is defined
-    # end block
+
   roles:
     - build_package
+
+  post_tasks:
+    - block:
+        - name: 'restore spec file'
+          copy:
+            src: "{{ original_specfile.backup }}"
+            dest: "{{ nightly_specfile_path }}"
+
+        - name: 'delete copied source files'
+          file:
+            state: absent
+            path: "{{ package_dir}}/{{ item | basename }}"
+          with_items: "{{ nightly_sourcefiles }}"
+      when: nightly_sourcefiles is defined and nightly_githash is defined


### PR DESCRIPTION
Koji is unable to release package using `--define <macro> <blah>`
because there's no way to pass that macro from local rpmbuild up. It
works fine when scratch building because koji will happily accept
whatever SRPM you hand it.

Actual releases are a different story though,
because koji rebuilds the SRPM (without having that macro we defined
locally) resulting in a release mismatch error.