### PR TITLE
Add Dockerfile to run Obal as a container

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,16 +13,15 @@ install:
   - chmod +x /home/travis/.local/bin/rpmdev-packager
 script:
   - tox
+  - docker build --build-arg VERSION=master -t quay.io/foreman/obal:latest .
 deploy:
-  provider: pypi
-  user: theforeman
-  password:
-    secure: HmlFYR1Nn325ZYPTWOorcw2qSQNrpxOiEmi3sd3EhVNlk0sR0582ujNY2cLquLxQkFFs3cjDdUVz1FNHC0PX5nOSbA7P0Ks4xZoU2MeXq+HLlreB2w2qcp2XfJXbSFh8ZfqoMCw83lsHkTBwkCYpy/jF6FNUSiP0hWp0aYNMVKwaLB2V8YggkyYStUqtLyq8BlKP1bxWqZTjVia9sk5ZpzG+sDMC/rzwlYDRzk6u9UFITmav6ONCFIsiwBuOTa9KcON21PQGJOBnP3HJB3iyPcGKI/3Ln5aUKVn36tN5hNu3s8VkqVumpxZir5qpqplsJdpY9tRwUTGyVP+CVA8wjxJYP3ziRQpJeHXVdDQ3pU1t9uOPp5Zgfp1Xbbl5QhcAQkHedQ27Xc3WlKdgXZO4dQpTnuFPW71j/J4EM29M1/0RecSYrVvefqWk7ZhIgX4VHydzM9n7VJcIGjXkY5JIWTgEwbXsw9E58iktefYy7+q/z059e0m3+vLJmuWIE+eucmN9pWdunS6GEL8fq9XDL5egtf0c//+mrjHj4u90+8w+TjzdVduqQyQVI3MZ68eM+Wlz0ChjOk32l2N9CmNjGXRFog2YbazZaJT0Z+mRMUlyQUNr6nzC4smsqX8UqzrdHI/g6s9klNoNWdjTF4afewElkQtX9NT0m5SVWAr12hg=
-  on:
-    tags: true
-    python: '3.6'
-script:
-  - tox
+  - provider: pypi
+    user: theforeman
+    password:
+      secure: HmlFYR1Nn325ZYPTWOorcw2qSQNrpxOiEmi3sd3EhVNlk0sR0582ujNY2cLquLxQkFFs3cjDdUVz1FNHC0PX5nOSbA7P0Ks4xZoU2MeXq+HLlreB2w2qcp2XfJXbSFh8ZfqoMCw83lsHkTBwkCYpy/jF6FNUSiP0hWp0aYNMVKwaLB2V8YggkyYStUqtLyq8BlKP1bxWqZTjVia9sk5ZpzG+sDMC/rzwlYDRzk6u9UFITmav6ONCFIsiwBuOTa9KcON21PQGJOBnP3HJB3iyPcGKI/3Ln5aUKVn36tN5hNu3s8VkqVumpxZir5qpqplsJdpY9tRwUTGyVP+CVA8wjxJYP3ziRQpJeHXVdDQ3pU1t9uOPp5Zgfp1Xbbl5QhcAQkHedQ27Xc3WlKdgXZO4dQpTnuFPW71j/J4EM29M1/0RecSYrVvefqWk7ZhIgX4VHydzM9n7VJcIGjXkY5JIWTgEwbXsw9E58iktefYy7+q/z059e0m3+vLJmuWIE+eucmN9pWdunS6GEL8fq9XDL5egtf0c//+mrjHj4u90+8w+TjzdVduqQyQVI3MZ68eM+Wlz0ChjOk32l2N9CmNjGXRFog2YbazZaJT0Z+mRMUlyQUNr6nzC4smsqX8UqzrdHI/g6s9klNoNWdjTF4afewElkQtX9NT0m5SVWAr12hg=
+    on:
+      tags: true
+      python: '3.6'
 addons:
   apt:
     packages:

--- a/.travis/deploy-container.sh
+++ b/.travis/deploy-container.sh
@@ -1,0 +1,4 @@
+#!/bin/bash -x
+
+docker build --build-arg VERSION=$1 -t quay.io/foreman/obal:latest .
+docker tag quay.io/foreman/obal:latest quay.io/foreman/obal:$1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM centos:7
+
+RUN echo "tsflags=nodocs" >> /etc/yum.conf && \
+    yum -y install epel-release git && \
+    yum -y install python2-pip && \
+    yum clean all
+
+ENV LANG=en_US.UTF-8
+ENV LANGUAGE=en_US.UTF-8
+ENV LC_ALL=en_US.UTF-8
+ENV PYTHONUNBUFFERED=0
+
+ARG VERSION=VERSION
+
+RUN pip install git+https://github.com/theforeman/obal.git@${VERSION}
+RUN obal setup
+
+RUN mkdir -p /opt/packaging
+WORKDIR /opt/packaging
+
+ENTRYPOINT ["/usr/bin/obal"]
+CMD ["--help"]

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,3 +3,6 @@ include LICENSE
 include .coveragerc
 include .pylintrc
 recursive-include rules *.py
+exclude Dockerfile
+exclude .travis
+recursive-exclude .travis *

--- a/README.md
+++ b/README.md
@@ -10,3 +10,11 @@ All `obal` actions should also work with plain Ansible when called like `ansible
 
 - `python` (2 or 3)
 - `ansible`
+
+## Using Obal via Container
+
+Obal and all it's required packages are available in a container that can be used locally or in build environments. The users Koji credentials and configuration must be mounted into the container alongside of mounting the packaging project into `/opt/packaging` to work. Note the examples below assume SELinux is disabled.
+
+To run (or sub `docker` for `podman`):
+
+    podman run -v `pwd`:/opt/packaging -v ~/.koji:/root/.koji obal:latest scratch katello


### PR DESCRIPTION
WIll require https://github.com/theforeman/obal/pull/159

Note I have not fully built out the Travis automatic deployment aspect as I want to ensure the build direction (i.e. from PyPi assets) is the direction we want to go. I wasn't sure how to handle credentials within the script deployer yet as well.