### PR TITLE
bump dates in test specs to avoid test failures

### DIFF
--- a/tests/fixtures/testrepo/copr/packages/hello/hello.spec
+++ b/tests/fixtures/testrepo/copr/packages/hello/hello.spec
@@ -47,5 +47,5 @@ fi
 %license COPYING
 
 %changelog
-* Tue Sep 06 2011 The Coon of Ty <Ty@coon.org> 2.10-1
+* Tue Dec 11 2018 The Coon of Ty <Ty@coon.org> 2.10-1
 - Initial version of the package

--- a/tests/fixtures/testrepo/downstream/packages/hello/hello.spec
+++ b/tests/fixtures/testrepo/downstream/packages/hello/hello.spec
@@ -47,5 +47,5 @@ fi
 %license COPYING
 
 %changelog
-* Tue Sep 06 2011 The Coon of Ty <Ty@coon.org> 2.9-1
+* Tue Dec 11 2018 The Coon of Ty <Ty@coon.org> 2.9-1
 - Initial version of the package

--- a/tests/fixtures/testrepo/downstream/packages/hello1/hello.spec
+++ b/tests/fixtures/testrepo/downstream/packages/hello1/hello.spec
@@ -47,5 +47,5 @@ fi
 %license COPYING
 
 %changelog
-* Tue Sep 06 2011 The Coon of Ty <Ty@coon.org> 2.9-1
+* Tue Dec 11 2018 The Coon of Ty <Ty@coon.org> 2.9-1
 - Initial version of the package

--- a/tests/fixtures/testrepo/upstream/packages/hello/hello.spec
+++ b/tests/fixtures/testrepo/upstream/packages/hello/hello.spec
@@ -47,5 +47,5 @@ fi
 %license COPYING
 
 %changelog
-* Tue Sep 06 2011 The Coon of Ty <Ty@coon.org> 2.10-1
+* Tue Dec 11 2018 The Coon of Ty <Ty@coon.org> 2.10-1
 - Initial version of the package

--- a/tests/fixtures/testrepo/upstream_bad_changelog/packages/hello/hello.spec
+++ b/tests/fixtures/testrepo/upstream_bad_changelog/packages/hello/hello.spec
@@ -47,5 +47,5 @@ fi
 %license COPYING
 
 %changelog
-* Tue Sep 06 2011 The Coon of Ty <Ty@coon.org> 2.10-1
+* Tue Dec 11 2018 The Coon of Ty <Ty@coon.org> 2.10-1
 - Initial version of the package

--- a/tests/fixtures/testrepo/upstream_with_epoch/packages/hello/hello.spec
+++ b/tests/fixtures/testrepo/upstream_with_epoch/packages/hello/hello.spec
@@ -46,5 +46,5 @@ fi
 %license COPYING
 
 %changelog
-* Tue Sep 06 2011 The Coon of Ty <Ty@coon.org> 2:2.10-1
+* Tue Dec 11 2018 The Coon of Ty <Ty@coon.org> 2:2.10-1
 - Initial version of the package


### PR DESCRIPTION
RPM in Fedora 29 started to skip changelog entries that are "too old" in
the output of "rpm --query --changelog".
While I consider this a bad move for RPM itself, I did not bother to try
to fix it there and just bumped the dates in our test changelogs.