### PR TITLE
add a workaround for annex not liking github sources

### DIFF
--- a/obal/data/roles/setup_sources/tasks/annex.yml
+++ b/obal/data/roles/setup_sources/tasks/annex.yml
@@ -24,6 +24,12 @@
     ( setup_sources_source_exists.stat.exists and setup_sources_source_exists.stat.islnk is defined
     and setup_sources_source_exists.stat.islnk )"
 
+- name: 'Remove source'
+  file:
+    name: "{{ setup_sources_sourcepath }}"
+    state: absent
+  when: setup_sources_search_annex is failed
+
 - name: 'Add url to annex for source'
   command: >-
     git annex addurl
@@ -35,3 +41,9 @@
     chdir: "{{ package_dir }}"
   ignore_errors: yes
   when: setup_sources_search_annex is failed
+
+- name: 'Ensure no actual change happened'
+  command: "git diff --exit-code {{ setup_sources_sourcebase }}"
+  changed_when: False
+  args:
+    chdir: "{{ package_dir }}"


### PR DESCRIPTION
github not always sends the "Content-Length" header when git annex tries
to fetch artifacts from there. some annex versions are more lax about
this (like the one in EPEL7), others (like in Fedora) bail out with:

    while adding a new url to an already annexed file, url does not have expected file size

this commit adds a workaround for this behaviour, by removing the old
annexed file before trying to add it. it is ensured that the newly added
file is identical by checking the result of git diff.

the workaround is disabled by default and needs to be enabled by passing

    setup_sources_annex_workaround=true