### PR TITLE
disable E306 for ansible-lint

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -6,4 +6,5 @@ skip_list:
   - ANSIBLE0012
   - '701'
   - '405'
+  - '306'
 parseable: true


### PR DESCRIPTION
E306 is "Shells that use pipes should set the pipefail option" which is
fair and all, but Ansible's `shell` module does not support setting
`pipefail` as an option. You need to set the `executable` option
explicitly to `/bin/bash` and then do something like
  `set -o pipefile && <the real command>`
and I refuse to write such an abomination in our playbooks.