### PR TITLE
allow multiple repositories as target for repoclosure

### DIFF
--- a/obal/data/roles/repoclosure/defaults/main.yml
+++ b/obal/data/roles/repoclosure/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
 repoclosure_additional_repos:  []
 repoclosure_config: repoclosure/el7.conf
-repoclosure_target_repo: downloaded_rpms
+repoclosure_target_repos: [ "{{ repoclosure_target_repo | default('downloaded_rpms') }}" ]
 repoclosure_lookaside_repos: []

--- a/obal/data/roles/repoclosure/tasks/main.yml
+++ b/obal/data/roles/repoclosure/tasks/main.yml
@@ -14,13 +14,14 @@
 - name: 'Run repoclosure'
   command: >
     repoclosure
-      -c {{ inventory_dir }}/{{ repoclosure_config }}
-      -t
-      -r {{ repoclosure_target_repo }}
-      {{ '--repofrompath=downloaded_rpms,./downloaded_rpms' if repoclosure_target_repo == 'downloaded_rpms' else '' }}
+      --config {{ inventory_dir }}/{{ repoclosure_config }}
+      --tempcache
+      --newest
+      --repoid {{ repoclosure_target_repos | join(' --repoid ') }}
+      {{ '--repofrompath=downloaded_rpms,./downloaded_rpms' if repoclosure_target_repos[0] == 'downloaded_rpms' else '' }}
       {{ additional_repos | join(' ') }}
-      {{ '-l ' if repoclosure_lookaside_repos else '' }}
-      {{ repoclosure_lookaside_repos | join(' -l ') }}
+      {{ '--lookaside ' if repoclosure_lookaside_repos else '' }}
+      {{ repoclosure_lookaside_repos | join(' --lookaside ') }}
   register: output
   when: output is not defined
   args:

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -396,7 +396,7 @@ def test_obal_repoclosure():
     assert_obal_success(['repoclosure', 'core-repoclosure'])
 
     expected_log = [
-        "repoclosure -c {pwd}/repoclosure/el7.conf -t -r downloaded_rpms --repofrompath=downloaded_rpms,./downloaded_rpms"  # noqa: E501
+        "repoclosure --config {pwd}/repoclosure/el7.conf --tempcache --newest --repoid downloaded_rpms --repofrompath=downloaded_rpms,./downloaded_rpms"  # noqa: E501
     ]
     assert_mockbin_log(expected_log)
 


### PR DESCRIPTION
with this change, you can pass

    repoclosure_target_repos:
      - downloaded_rpms
      - el7-foreman-nightly
      - el7-foreman-plugins-nightly
      …

this will allow to check that not only the newly built RPM set in
downloaded_rpms can be actually installed, but also that the new RPMs
don't break any other RPM dependencies in our repositories.

for this to work we also need to pass --newest to repoclosure, as
otherwise older versions of the RPMs we just built would satisfy the
dependency.

as a side-change this also flips all params we pass to repoclosure to
--longopt for better readability