### PR TITLE
Clean up playbook help text formatting

### DIFF
--- a/obal/data/playbooks/add/metadata.obal.yaml
+++ b/obal/data/playbooks/add/metadata.obal.yaml
@@ -1,22 +1,19 @@
-help: >
+help: |
   Add a new package from an upstream repo to a downstream one.
-
 
   Typically this is used to copy a package from `foreman-packaging` to a downstream product repository. It's currently not possible to add a vanilla new package to `foreman-packaging`.
 
-
   To add a new package from upstream, start by adding an entry to `package_manifest.yaml` in the appropriate section (server, client, capsule, etc):
 
-  my-new-package:
-    upstream_files:
-      - "my-new-package/"
+    my-new-package:
+      upstream_files:
+        - "my-new-package/"
 
   The minimum fields required are the package's name and upstream_files which lists files to copy from the upstream repository. Entries in upstream_files can be file paths, or directories (denoted with a trailing slash).
 
     obal add my-new-package
 
   If all goes well, you should have a new directory in packages/ containing the spec and any sources.
-
 
   Sometimes `add` won't work due to your new packaging being in a non-standard location (in EPEL, for instance) then you'll need to do everything that add_package.yml does manually.
 

--- a/obal/data/playbooks/bump-release/metadata.obal.yaml
+++ b/obal/data/playbooks/bump-release/metadata.obal.yaml
@@ -1,4 +1,4 @@
-help: >
+help: |
   This action updates a spec file's release field and adds a pre-formatted changelog entry.
 variables:
   changelog:

--- a/obal/data/playbooks/changelog/metadata.obal.yaml
+++ b/obal/data/playbooks/changelog/metadata.obal.yaml
@@ -1,4 +1,4 @@
-help: >
+help: |
   The changelog command writes a RPM changelog entry for the current version and release.
 variables:
   changelog:

--- a/obal/data/playbooks/check/metadata.obal.yaml
+++ b/obal/data/playbooks/check/metadata.obal.yaml
@@ -1,1 +1,2 @@
-help: This action verifies that the packages defined in git are also built into Koji/Brew/Copr.
+help: |
+  This action verifies that the packages defined in git are also built into Koji/Brew/Copr.

--- a/obal/data/playbooks/cleanup-copr/metadata.obal.yaml
+++ b/obal/data/playbooks/cleanup-copr/metadata.obal.yaml
@@ -1,2 +1,2 @@
-help: >
+help: |
   This action cleans up stale Copr scratch repos.

--- a/obal/data/playbooks/lint/metadata.obal.yaml
+++ b/obal/data/playbooks/lint/metadata.obal.yaml
@@ -1,2 +1,2 @@
-help: >
+help: |
   Run rpmlint on a spec file and reports the results

--- a/obal/data/playbooks/nightly/metadata.obal.yaml
+++ b/obal/data/playbooks/nightly/metadata.obal.yaml
@@ -1,6 +1,5 @@
-help: >
+help: |
   Build a nightly version of a package
-
 
   This typically uses unreleased sources taken from a git repository.
 variables:

--- a/obal/data/playbooks/release/metadata.obal.yaml
+++ b/obal/data/playbooks/release/metadata.obal.yaml
@@ -1,5 +1,4 @@
-help: >
+help: |
   This action releases a package to Koji/Brew/Copr
-
 
   No action is performed if a release of the exact same version already exists.

--- a/obal/data/playbooks/repoclosure/metadata.obal.yaml
+++ b/obal/data/playbooks/repoclosure/metadata.obal.yaml
@@ -1,5 +1,4 @@
-help: >
+help: |
   Run repoclosure for a repository
-
 
   Repoclosure ensures that all dependencies are met and all packages are installable.

--- a/obal/data/playbooks/scratch/metadata.obal.yaml
+++ b/obal/data/playbooks/scratch/metadata.obal.yaml
@@ -1,5 +1,4 @@
-help: >
+help: |
   Create a scratch build of a package
-
 
   A scratch build produces the same result as a normal release would, but it's not tagged in any repository. This allows verification of a change without actually committing it.

--- a/obal/data/playbooks/setup/metadata.obal.yaml
+++ b/obal/data/playbooks/setup/metadata.obal.yaml
@@ -1,2 +1,2 @@
-help: >
+help: |
   This action installs packages required for proper obal usage on your machine.

--- a/obal/data/playbooks/source/metadata.obal.yaml
+++ b/obal/data/playbooks/source/metadata.obal.yaml
@@ -1,5 +1,4 @@
-help: >
+help: |
   Setup sources for a package
-
 
   When using git annex we only store a reference to a the actual source. This command retrieves the sources from the remote. These are usually tarballs or gems.

--- a/obal/data/playbooks/srpm/metadata.obal.yaml
+++ b/obal/data/playbooks/srpm/metadata.obal.yaml
@@ -1,6 +1,5 @@
-help: >
+help: |
   Build a SRPM for packages
-
 
   Building source RPMs can be useful when locally building packages.
 variables:

--- a/obal/data/playbooks/update/metadata.obal.yaml
+++ b/obal/data/playbooks/update/metadata.obal.yaml
@@ -1,9 +1,7 @@
-help: >
+help: |
   Update a package to a newer version
 
-
   The newer version is either taken from an upstream repository or can be given via command line options.
-
 
   To update a package to a new version from the command line:
 

--- a/tests/fixtures/help/add.txt
+++ b/tests/fixtures/help/add.txt
@@ -5,9 +5,10 @@ Add a new package from an upstream repo to a downstream one.
 Typically this is used to copy a package from `foreman-packaging` to a downstream product repository. It's currently not possible to add a vanilla new package to `foreman-packaging`.
 
 To add a new package from upstream, start by adding an entry to `package_manifest.yaml` in the appropriate section (server, client, capsule, etc):
-my-new-package:
-  upstream_files:
-    - "my-new-package/"
+
+  my-new-package:
+    upstream_files:
+      - "my-new-package/"
 
 The minimum fields required are the package's name and upstream_files which lists files to copy from the upstream repository. Entries in upstream_files can be file paths, or directories (denoted with a trailing slash).
 


### PR DESCRIPTION
The pipe formatting preserves newlines and is actually how most help texts are formatted anyway.