### PR TITLE
run the "right" repoclosure, even if there is a downloaded_rpms folder

### DIFF
--- a/obal/data/roles/repoclosure/tasks/main.yml
+++ b/obal/data/roles/repoclosure/tasks/main.yml
@@ -29,7 +29,9 @@
   loop: "{{ downloaded_rpms_dists }}"
   loop_control:
     loop_var: dist
-  when: downloaded_rpms_dists
+  when:
+    - downloaded_rpms_dists
+    - repoclosure_target_dist is not defined
 
 - name: Run repoclosure for main repo
   include_tasks: repoclosure.yml
@@ -39,4 +41,5 @@
     - "{{ repoclosure_target_dist }}"
   loop_control:
     loop_var: dist
-  when: not downloaded_rpms_dists
+  when:
+    - repoclosure_target_dist is defined


### PR DESCRIPTION
we might want to run one of the special repoclosure targets, even if
there is a downloaded_rpms in our pwd