### PR TITLE
Fix bare variable deprecation warning

### DIFF
--- a/obal/data/playbooks/release/release.yaml
+++ b/obal/data/playbooks/release/release.yaml
@@ -6,4 +6,4 @@
   roles:
     - diff_package
     - role: build_package
-      when: diff_package_changed
+      when: diff_package_changed|bool


### PR DESCRIPTION
This fixes the following deprecation warning with Ansible 2.8:

[DEPRECATION WARNING]: evaluating diff_package_changed as a bare variable, this behaviour will go away and you might need to add |bool to the expression in the future. Also see CONDITIONAL_BARE_VARS configuration toggle.. This feature will be removed in version 2.12.  Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.

Fixes #197