### PR TITLE
Add ability to update spec files for nodejs and gems

### DIFF
--- a/obal/data/modules/changelog.py
+++ b/obal/data/modules/changelog.py
@@ -50,7 +50,7 @@ def main():
 
     changed = False
 
-    if entry and not entry.startswith('-'):
+    if entry is not None and not entry.startswith('-'):
         entry = '- ' + entry
 
     for i, line in enumerate(lines):

--- a/obal/data/playbooks/update-spec/metadata.obal.yaml
+++ b/obal/data/playbooks/update-spec/metadata.obal.yaml
@@ -1,0 +1,11 @@
+help: |
+  Update a package's specfile based on a template
+
+    obal update-spec mypackage --type gem --template gem2rpm/scl.spec.erb
+variables:
+  template:
+    help: The template to use for updates
+  type:
+    help: The type of package being updated (e.g. gem)
+  strategy:
+    help: The strategy to use for an NPM package

--- a/obal/data/playbooks/update-spec/update-spec.yaml
+++ b/obal/data/playbooks/update-spec/update-spec.yaml
@@ -1,0 +1,10 @@
+---
+- hosts:
+    - packages
+  serial: 1
+  gather_facts: no
+  roles:
+    - role: setup_sources
+      when: type == 'gem'
+    - spec_file
+    - update_spec_file

--- a/obal/data/playbooks/update/metadata.obal.yaml
+++ b/obal/data/playbooks/update/metadata.obal.yaml
@@ -27,3 +27,7 @@ variables:
   commit:
     help: When true, creates a git branch and commits the update changes to it.
     action: store_true
+  template:
+    help: The template to use for spec file updates
+  type:
+    help: The type of package being updated

--- a/obal/data/playbooks/update/update.yaml
+++ b/obal/data/playbooks/update/update.yaml
@@ -51,6 +51,14 @@
       when:
         - "'://' not in item"
 
+    - name: "Remove old sources"
+      command: "git rm --ignore-unmatch {{ item | basename }}"
+      args:
+        chdir: "{{ inventory_dir }}/{{ package_base_dir }}/{{ inventory_hostname }}"
+      with_items: "{{ old_source_urls.stdout_lines | list }}"
+      when:
+        - "'://' in item"
+
 - hosts:
     - packages
   gather_facts: false

--- a/obal/data/roles/fetch_sources/tasks/main.yml
+++ b/obal/data/roles/fetch_sources/tasks/main.yml
@@ -89,10 +89,10 @@
         - changelog is not defined
         - version is defined
 
-    - name: 'update spec file'
-      include_role:
-        name: update_spec_file
-
     - name: 'update source files'
       include_role:
         name: setup_sources
+
+    - name: 'update spec file'
+      include_role:
+        name: update_spec_file

--- a/obal/data/roles/update_spec_file/tasks/main.yml
+++ b/obal/data/roles/update_spec_file/tasks/main.yml
@@ -58,8 +58,103 @@
     - release is defined
     - release != 'keep'
 
+- name: Set type
+  set_fact:
+    type: 'npm'
+  when: type is not defined and 'nodejs' in inventory_hostname
+
+- name: Set type
+  set_fact:
+    type: 'gem'
+  when: type is not defined and 'rubygem' in inventory_hostname
+
 - name: 'add changelog entry'
   changelog:
     spec: "{{ spec_file_path }}"
     entry: "{{ changelog }}"
   when: changelog is defined
+
+- name: Read changelog
+  changelog:
+    spec: "{{ spec_file_path }}"
+  register: changelog
+
+- when: type == 'tar'
+  block:
+    - import_role:
+        name: setup_sources
+
+- when: type == 'gem'
+  block:
+    - import_role:
+        name: setup_sources
+
+    - name: Run spec update template
+      shell: "gem2rpm -o {{ spec_file_path }} -t {{ template }} {{ inventory_dir }}/{{ package_base_dir }}/{{ inventory_hostname }}/*-{{ version }}.gem"
+      args:
+        chdir: "{{ inventory_dir }}"
+
+    - name: Add back changelog
+      lineinfile:
+        path: "{{ spec_file_path }}"
+        insertafter: "%changelog"
+        line: "{{ changelog.changelog }}"
+
+- when: type == 'npm'
+  block:
+    - name: Find version
+      shell: "rpmspec --srpm -q --queryformat=%{version} {{ spec_file_path }}"
+      args:
+        chdir: "{{ inventory_dir }}"
+      register: version_output
+      when: version is not defined
+
+    - name: Find release
+      shell: "rpmspec --srpm -q --queryformat=%{release} {{ spec_file_path }}"
+      args:
+        chdir: "{{ inventory_dir }}"
+      register: release_output
+      when: release is not defined
+
+    - name: Set version
+      set_fact:
+        version: "{{ version_output.stdout }}"
+      when: version is not defined
+
+    - name: Set release
+      set_fact:
+        release: "{{ release_output.stdout }}"
+      when: release is not defined
+
+    - name: Find all sources to remove
+      find:
+        paths: "{{ inventory_dir }}/{{ package_base_dir }}/{{ inventory_hostname }}"
+        patterns: "*.tgz"
+        file_type: any
+      register: files_to_remove
+
+    - name: Remove old sources
+      file:
+        state: absent
+        path: "{{ item.path }}"
+      with_items: "{{ files_to_remove.files }}"
+
+    - name: Run spec update template
+      command: "npm2rpm -s {{ strategy | default('single') }} -n {{ name | default(inventory_hostname.replace('nodejs-', '')) }} -v {{ version }} -o . -c"
+      args:
+        chdir: "{{ inventory_dir }}/{{ package_base_dir }}/{{ inventory_hostname }}"
+
+    - name: Add release back
+      replace:
+        path: "{{ spec_file_path }}"
+        regexp: "Release: 1"
+        replace: "Release: {{ release }}"
+
+    - import_role:
+        name: setup_sources
+
+    - name: Add back changelog
+      lineinfile:
+        path: "{{ spec_file_path }}"
+        insertafter: "%changelog"
+        line: "{{ changelog.changelog }}"


### PR DESCRIPTION
This includes another PR thats required. This adds the ability to update just the spec file of a package (for NPM and Gems) and thus do it en masse. The playbook is a bit messy and I am willing to break it up depending on how folks feel about the design.