### PR TITLE
workaround git annex annexing ALL files

### DIFF
--- a/obal/data/playbooks/update/update.yaml
+++ b/obal/data/playbooks/update/update.yaml
@@ -44,7 +44,7 @@
         - "'://' in item"
 
     - name: 'Git add new sources'
-      command: "git add ./{{ package_base_dir }}/{{ inventory_hostname }}/{{ item | basename }}"
+      command: "git -c annex.largefiles=nothing add ./{{ package_base_dir }}/{{ inventory_hostname }}/{{ item | basename }}"
       args:
         chdir: "{{ inventory_dir }}"
       with_items: "{{ new_source_urls.stdout_lines | list }}"

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -24,7 +24,7 @@ if os.environ.get('TRAVIS', None):
 def git_init(path):
     subprocess.check_call(['git', 'init'], cwd=path)
     subprocess.check_call(['git', 'annex', 'init'], cwd=path)
-    subprocess.check_call(['git', 'add', '.'], cwd=path)
+    subprocess.check_call(['git', '-c', 'annex.largefiles=nothing', 'add', '.'], cwd=path)
     subprocess.check_call(['git', 'commit', '-a', '-m', 'init'], cwd=path)
 
 


### PR DESCRIPTION
git annex between 7.20190912 and 7.20191024 defaults to annexing ALL
files, even those added via `git add`. this forces it not to do so in
`obal update` and the tests.

`obal add` is still broken, though.