### PR TITLE
only reset the prerelease macro if a version was passed

### DIFF
--- a/obal/data/roles/update_spec_file/tasks/main.yml
+++ b/obal/data/roles/update_spec_file/tasks/main.yml
@@ -33,7 +33,9 @@
     path: "{{ spec_file_path }}"
     regexp: '^%global prerelease'
     state: absent
-  when: prerelease is not defined
+  when:
+    - prerelease is not defined
+    - version is defined
 
 - name: 'Bump release in specfile'
   replace:


### PR DESCRIPTION
otherwise we break "update from upstream" scenario