### PR TITLE
Run scratch packages in parallel

### DIFF
--- a/obal/data/ansible.cfg
+++ b/obal/data/ansible.cfg
@@ -9,3 +9,4 @@ display_skipped_hosts = false
 roles_path = ./roles/
 library = ./modules
 module_utils = ./module_utils
+strategy = free

--- a/obal/data/playbooks/scratch/scratch.yaml
+++ b/obal/data/playbooks/scratch/scratch.yaml
@@ -1,7 +1,7 @@
 ---
 - hosts:
     - packages
-  serial: 1
+  # serial: 1
   any_errors_fatal: false # don't bomb out the entire playbook if one host (i.e. package) fails
   gather_facts: no
   vars:


### PR DESCRIPTION
This isn't necessarily the final implementation, but opening the PR for conversation.

I ran the entire nodejs group in foreman-packaging with these modifications and ran into no issues from what I could tell.

This will allow us to send all the packages over to koji in a big lump, and let koji work through the queue instead of having to do one package at a time.