### PR TITLE
Don't re-copy files that exist.

### DIFF
--- a/obal/tito_extensions/git_annex_spec_builder.py
+++ b/obal/tito_extensions/git_annex_spec_builder.py
@@ -132,8 +132,11 @@ class GitAnnexSpecBuilder(GitAnnexBuilder):
             for artifact in dir_artifacts_with_path:
                 debug("  Copying source file %s" % artifact)
                 if os.path.isfile(artifact):
-                    shutil.copy(artifact, self.rpmbuild_gitcopy)
-                    shutil.copy(artifact, self.rpmbuild_sourcedir)
+                    if not os.path.exists("/".join([self.rpmbuild_gitcopy, os.path.basename(artifact)])):
+                        shutil.copy(artifact, self.rpmbuild_gitcopy)
+                    if not os.path.exists("/".join([self.rpmbuild_sourcedir, os.path.basename(artifact)])):
+                        shutil.copy(artifact, self.rpmbuild_sourcedir)
+
 
         # NOTE: The spec file we actually use is the one exported by git
         # archive into the temp build directory. This is done so we can


### PR DESCRIPTION
Not entirely sure why, but in certain situations, tito will try to recopy assets to the temp directory.  This fails with annex files because they have 444 (r--r--r--) permisisons, and are therefore unwriteable.  Given the narrow window and the very short lifetime of the temp directory (just the life of the tito command), it should be safe to not copy again