### PR TITLE
Use koji directly for release tasks

### DIFF
--- a/obal/data/module_utils/obal.py
+++ b/obal/data/module_utils/obal.py
@@ -58,12 +58,15 @@ def get_specfile_nevr(specfile, scl=None, dist=None, macros=None):
     return specfile_macro_lookup(specfile, '%{nevr}', scl=scl, dist=dist, macros=macros)
 
 
-def get_whitelist_status(build_command, tag, package):
+def package_exists(build_command, tag, package):
     """
-    Get whitelist status of a given package within a tag.
+    Check if package exists within a tag.
 
-    Return `True` if the package is whitelisted, `False` otherwise.
+    Return `True` if the package is added to the tag, `False` otherwise.
     """
+    if not build_command:
+        build_command = 'koji'
+
     cmd = [
         build_command,
         'list-pkgs',

--- a/obal/data/modules/koji_build.py
+++ b/obal/data/modules/koji_build.py
@@ -1,0 +1,69 @@
+"""
+Release a package to koji
+"""
+
+import re
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.koji_wrapper import koji, KojiCommandError # pylint:disable=import-error,no-name-in-module
+from ansible.module_utils.obal import package_exists  # pylint:disable=import-error,no-name-in-module
+
+
+def main():
+    """
+    Build a package in koji
+    """
+    module = AnsibleModule(
+        argument_spec=dict(
+            srpm=dict(type='path', required=True),
+            scratch=dict(type='bool', required=False, default=False),
+            tag=dict(type='str', required=True),
+            nevr=dict(type='str', required=True),
+            package=dict(type='str', required=True),
+            tag_check=dict(type='bool', required=False, default=True),
+            koji_executable=dict(type='str', required=False)
+        )
+    )
+
+    tag = module.params['tag']
+    scratch = module.params['scratch']
+    srpm = module.params['srpm']
+    nevr = module.params['nevr']
+    package = module.params['package']
+    koji_executable = module.params['koji_executable']
+
+    if module.params['tag_check']:
+        if not package_exists(module.params['koji_executable'], tag, package):
+            module.fail_json(msg="Package {} has not been added to tag {}".format(package, tag))
+
+    if not scratch:
+        try:
+            command = ['latest-build', '--quiet', tag, package]
+            koji_output = koji(command, koji_executable)
+            build = koji_output.split(' ')[0]
+
+            if build == nevr:
+                module.exit_json(changed=False, build=build)
+        except KojiCommandError as error:
+            module.fail_json(changed=False, msg=error, command=command)
+
+    command = ['build', tag, srpm]
+
+    if scratch:
+        command.append('--scratch')
+
+    try:
+        output = koji(command, koji_executable)
+    except KojiCommandError as error:
+        module.fail_json(msg='Failed to koji build', command=error.cmd, output=error.output,
+                         tag=tag, scratch=scratch, srpm=srpm, code=error.returncode)
+
+    tasks = re.findall(r'^Created task:\s(\d+)', output, re.MULTILINE)
+    task_urls = re.findall(r'^Task info:\s(.+)', output, re.MULTILINE)
+    builds = re.findall(r'^Created builds:\s(\d+)', output, re.MULTILINE)
+
+    module.exit_json(changed=True, output=output, tasks=tasks, task_urls=task_urls, builds=builds)
+
+
+if __name__ == '__main__':
+    main()

--- a/obal/data/modules/package_tag_check.py
+++ b/obal/data/modules/package_tag_check.py
@@ -8,13 +8,7 @@ except ImportError:
 import os
 
 from ansible.module_utils.basic import AnsibleModule  # pylint: disable=C0413
-from ansible.module_utils.obal import get_specfile_name, get_whitelist_status  # pylint:disable=import-error,no-name-in-module
-
-ANSIBLE_METADATA = {
-    'metadata_version': '1.2',
-    'status': ['preview'],
-    'supported_by': 'community'
-}
+from ansible.module_utils.obal import get_specfile_name, package_exists  # pylint:disable=import-error,no-name-in-module
 
 
 def run_module():
@@ -31,7 +25,7 @@ def run_module():
         changed=False,
         branches=[],
         autobuild_tags=[],
-        whitelist_status=dict(),
+        status=dict(),
     )
 
     releasers_config = module.params['releasers_conf']
@@ -56,13 +50,12 @@ def run_module():
     if not result['branches'] and not result['autobuild_tags']:
         module.fail_json(msg="No branches or autobuild_tags were found mapped to {}.".format(module.params['releasers']), **result)
 
-    # check whitelist status
     for tag in result['branches'] + result['autobuild_tags']:
-        status = get_whitelist_status(module.params['build_command'], tag, package_name)
-        result['whitelist_status'][tag] = status
+        status = package_exists(module.params['build_command'], tag, package_name)
+        result['status'][tag] = status
 
-    if not all(result['whitelist_status'].values()):
-        module.fail_json(msg="Package has not been whitelisted for given branches and autobuild_tags", **result)
+    if not all(result['status'].values()):
+        module.fail_json(msg="Package has not been added to given branches and autobuild_tags", **result)
 
     module.exit_json(**result)
 

--- a/obal/data/playbooks/nightly/metadata.obal.yaml
+++ b/obal/data/playbooks/nightly/metadata.obal.yaml
@@ -14,7 +14,7 @@ variables:
     parameter: --scratch
     action: store_true
     help: Set --scratch for scratch builds.
-  build_package_koji_whitelist_check:
+  build_package_koji_tag_check:
     action: store_false
-    parameter: --skip-koji-whitelist-check
-    help: ignore koji whitelist check and release the package anyway
+    parameter: --skip-koji-tag-check
+    help: ignore koji tag check and release the package anyway

--- a/obal/data/playbooks/nightly/nightly.yaml
+++ b/obal/data/playbooks/nightly/nightly.yaml
@@ -3,24 +3,15 @@
     - packages
   serial: 1
   gather_facts: false
-  vars:
-    build_package_tito_releaser_args: "{{ nightly_package_tito_releaser_args | default([]) }}"
   roles:
     - package_variables
   tasks:
-    - name: 'legacy nightly building'
-      block:
-        - name: 'set nightly_releaser'
-          set_fact:
-            releasers:
-              - "{{ nightly_releaser }}"
+    - name: 'Check for nightly_sourcefiles and nightly_githash'
+      fail:
+        msg: "nightly_sourcefiles and nightly_githash must be defined"
+      when: nightly_sourcefiles is not defined or nightly_githash is not defined
 
-        - import_role:
-            name: build_package
-      when: nightly_sourcefiles is not defined and nightly_githash is not defined
-
-    - name: 'nightly building'
-      block:
+    - block:
         - name: 'set package_dir'
           set_fact:
             package_dir: "{{ inventory_dir }}/{{ package_base_dir }}/{{ inventory_hostname }}"
@@ -30,12 +21,24 @@
             global_nightly_macro:
               "%global nightly .{{ lookup('pipe', 'date +%Y%m%d%H%M%S') }}git{{ nightly_githash[:7] }}"
 
+        - name: 'get source files'
+          find:
+            pattern: "*"
+            path: "{{ nightly_sourcefiles }}"
+          register: source_files
+
         - name: 'copy source files'
           copy:
-            src: "{{ item }}"
+            src: "{{ item.path }}"
             dest: "{{ package_dir }}"
             mode: preserve
-          with_items: "{{ nightly_sourcefiles }}"
+          with_items: "{{ source_files.files }}"
+
+        - name: 'Annex source files'
+          command: "git annex add {{ item.path | basename }}"
+          args:
+            chdir: "{{ package_dir }}"
+          with_items: "{{ source_files.files }}"
 
         - name: 'get nightly_specfile'
           find:
@@ -43,13 +46,13 @@
             path: "{{ package_dir }}"
           register: nightly_specfile
 
-        - name: 'set nightly_specfile_path'
+        - name: 'set spec_file_path'
           set_fact:
-            nightly_specfile_path: "{{ nightly_specfile.files[0].path }}"
+            spec_file_path: "{{ nightly_specfile.files[0].path }}"
 
         - name: 'add nightly macro to specfile'
           lineinfile:
-            path: "{{ nightly_specfile_path }}"
+            path: "{{ spec_file_path }}"
             line: "{{ global_nightly_macro }}"
             insertbefore: BOF
             backup: true
@@ -57,18 +60,35 @@
 
         - import_role:
             name: build_package
-      when: nightly_sourcefiles is defined and nightly_githash is defined
+          vars:
+            setup_sources_skip: true
       always:
+        - name: 'set package_dir'
+          set_fact:
+            package_dir: "{{ inventory_dir }}/{{ package_base_dir }}/{{ inventory_hostname }}"
+
         - name: 'restore spec file'
           copy:
             src: "{{ original_specfile.backup }}"
-            dest: "{{ nightly_specfile_path }}"
+            dest: "{{ spec_file_path }}"
             mode: preserve
           when: original_specfile is defined
+
+        - name: 'delete spec file copy'
+          file:
+            state: absent
+            path: "{{ package_dir }}/{{ original_specfile.backup }}"
+
+        - name: 'remote annexed source files'
+          command: "git annex undo {{ item.path | basename }}"
+          with_items: "{{ source_files.files }}"
+          when: source_files is defined
+          args:
+            chdir: "{{ package_dir }}"
 
         - name: 'delete copied source files'
           file:
             state: absent
-            path: "{{ package_dir }}/{{ item | basename }}"
-          with_items: "{{ nightly_sourcefiles }}"
-          when: nightly_sourcefiles is defined
+            path: "{{ package_dir }}/{{ item.path | basename }}"
+          with_items: "{{ source_files.files }}"
+          when: source_files is defined

--- a/obal/data/playbooks/release/metadata.obal.yaml
+++ b/obal/data/playbooks/release/metadata.obal.yaml
@@ -4,7 +4,7 @@ help: |
 
   No action is performed if a release of the exact same version already exists.
 variables:
-  build_package_koji_whitelist_check:
+  build_package_koji_tag_check:
     action: store_false
-    parameter: --skip-koji-whitelist-check
-    help: ignore koji whitelist check and release the package anyway
+    parameter: --skip-koji-tag-check
+    help: ignore koji tag check and release the package anyway

--- a/obal/data/playbooks/release/release.yaml
+++ b/obal/data/playbooks/release/release.yaml
@@ -4,6 +4,6 @@
   serial: 1
   gather_facts: false
   roles:
-    - diff_package
+    - role: diff_package
     - role: build_package
-      when: diff_package_changed|bool
+      when: diff_package_changed

--- a/obal/data/playbooks/scratch/metadata.obal.yaml
+++ b/obal/data/playbooks/scratch/metadata.obal.yaml
@@ -4,7 +4,7 @@ help: |
 
   A scratch build produces the same result as a normal release would, but it's not tagged in any repository. This allows verification of a change without actually committing it.
 variables:
-  build_package_koji_whitelist_check:
+  build_package_koji_tag_check:
     action: store_false
-    parameter: --skip-koji-whitelist-check
-    help: ignore koji whitelist check and scratch build the package anyway
+    parameter: --skip-koji-tag-check
+    help: ignore koji tag check and scratch build the package anyway

--- a/obal/data/roles/build_package/defaults/main.yaml
+++ b/obal/data/roles/build_package/defaults/main.yaml
@@ -9,5 +9,5 @@ build_package_wait: true
 build_package_download_logs: false
 build_package_download_rpms: false
 build_package_waitrepo: false
-build_package_koji_whitelist_check: false
+build_package_koji_tag_check: false
 build_package_tito_builder:

--- a/obal/data/roles/build_package/meta/main.yml
+++ b/obal/data/roles/build_package/meta/main.yml
@@ -2,3 +2,4 @@
 dependencies:
   - role: setup_workspace
   - role: setup_sources
+    when: not setup_sources_skip

--- a/obal/data/roles/build_package/tasks/koji.yml
+++ b/obal/data/roles/build_package/tasks/koji.yml
@@ -1,40 +1,50 @@
 ---
-- name: "Confirm package is whitelisted"
-  package_whitelist_check:
-    releasers_conf: "{{ inventory_dir }}/rel-eng/releasers.conf"
-    spec_file_path: "{{ spec_file_path }}"
-    releasers: "{{ releasers }}"
-    build_command: "{{ build_package_koji_command }}"
-  when: build_package_koji_whitelist_check | bool
+- when: koji_tags|length == 0
+  block:
+    - name: "Confirm package is added to tag"
+      package_tag_check:
+        releasers_conf: "{{ inventory_dir }}/rel-eng/releasers.conf"
+        spec_file_path: "{{ spec_file_path }}"
+        releasers: "{{ releasers }}"
+        build_command: "{{ build_package_koji_command }}"
+      when: build_package_koji_tag_check | bool
 
-- name: 'Set tito_releasers for brew scratch'
-  set_fact:
-    build_package_tito_releasers: "{{ releasers | map('replace', 'dist-git', 'scratch') | list }}"
-  when: build_package_koji_command == 'brew' and build_package_scratch
+    - name: 'Set tito_releasers for brew scratch'
+      set_fact:
+        build_package_tito_releasers: "{{ releasers | map('replace', 'dist-git', 'scratch') | list }}"
+      when: build_package_koji_command == 'brew' and build_package_scratch
 
-- name: 'Set tito_releasers'
-  set_fact:
-    build_package_tito_releasers: "{{ releasers }}"
-  when: build_package_koji_command != 'brew' or not build_package_scratch
+    - name: 'Set tito_releasers'
+      set_fact:
+        build_package_tito_releasers: "{{ releasers }}"
+      when: build_package_koji_command != 'brew' or not build_package_scratch
 
-- name: 'Release to {{ build_package_koji_command }}'
-  tito_release:
-    directory: "{{ inventory_dir }}/{{ package_base_dir }}/{{ inventory_hostname }}"
-    arguments: "{{ build_package_tito_args }}"
-    scratch: "{{ build_package_scratch and build_package_koji_command != 'brew'}}"
-    test: "{{ build_package_test }}"
-    releasers: "{{ build_package_tito_releasers }}"
-    releaser_arguments: "{{ build_package_tito_releaser_args }}"
-  register: build_package_tito_release
+    - name: 'Release to {{ build_package_koji_command }}'
+      tito_release:
+        directory: "{{ inventory_dir }}/{{ package_base_dir }}/{{ inventory_hostname }}"
+        arguments: "{{ build_package_tito_args }}"
+        scratch: "{{ build_package_scratch and build_package_koji_command != 'brew'}}"
+        test: "{{ build_package_test }}"
+        releasers: "{{ build_package_tito_releasers }}"
+        releaser_arguments: "{{ build_package_tito_releaser_args }}"
+      register: build_package_tito_release
 
-- name: 'Created tasks'
-  debug:
-    var: build_package_tito_release.task_urls
+    - name: 'Created tasks'
+      debug:
+        var: build_package_tito_release.task_urls
 
-- name: 'Wait for tasks to finish'
-  include_tasks: wait.yml
-  when: build_package_wait|bool
+    - name: 'Wait for tasks to finish'
+      include_tasks: wait.yml
+      when: build_package_wait|bool
 
-- name: 'Download task results'
-  include_tasks: download_rpms.yml
-  when: build_package_download_rpms|bool
+    - name: 'Download task results'
+      include_tasks: download_rpms.yml
+      when: build_package_download_rpms|bool
+
+
+- when: koji_tags|length > 0
+  block:
+    - include_tasks: koji_build.yml
+      loop: "{{ koji_tags }}"
+      loop_control:
+        loop_var: tag

--- a/obal/data/roles/build_package/tasks/koji_build.yml
+++ b/obal/data/roles/build_package/tasks/koji_build.yml
@@ -1,0 +1,44 @@
+---
+- name: "Package name"
+  rpm_nevr:
+    spec_file: "{{ spec_file_path }}"
+    scl: "{{ tag.scl | default(omit) }}"
+    dist: "{{ tag.dist | default(omit) }}"
+    macros: "{{ tag.macros | default(omit) }}"
+  register: package_nevr
+
+- name: create temporary build directory
+  tempfile:
+    state: directory
+    suffix: srpms
+  register: srpm_directory
+  when: srpm_directory is not defined
+
+- name: 'Build SRPM'
+  srpm:
+    package: "{{ inventory_dir }}/{{ package_base_dir }}/{{ inventory_hostname }}"
+    output: "{{ srpm_directory.path if 'path' in srpm_directory else srpm_directory }}"
+    scl: "{{ scl | default(omit) }}"
+    source_location: "{{ source_location | default(omit) }}"
+    source_system: "{{ source_system | default(omit) }}"
+  register: srpm_build
+
+- name: "Scratch build"
+  koji_build:
+    scratch: "{{ build_package_scratch }}"
+    tag: "{{ tag.name }}"
+    srpm: "{{ srpm_build.path }}"
+    package: "{{ package_nevr.name }}"
+    nevr: "{{ package_nevr.nevr }}"
+    koji_executable: "{{ build_package_koji_command }}"
+    tag_check: "{{ build_package_koji_tag_check }}"
+  register: build_package_tito_release
+
+- name: 'Created tasks'
+  debug:
+    var: build_package_tito_release.task_urls
+  when: build_package_tito_release.changed
+
+- name: 'Wait for tasks to finish'
+  include_tasks: wait.yml
+  when: build_package_wait|bool and build_package_tito_release.changed

--- a/obal/data/roles/diff_package/defaults/main.yaml
+++ b/obal/data/roles/diff_package/defaults/main.yaml
@@ -3,3 +3,4 @@ diff_package_type: koji
 diff_package_koji_command: koji
 diff_package_skip: false
 scl: false
+diff_package_changed: false

--- a/obal/data/roles/diff_package/tasks/koji_old.yml
+++ b/obal/data/roles/diff_package/tasks/koji_old.yml
@@ -1,9 +1,4 @@
 ---
-- name: Set koji_tags if diff_package_tags is defined
-  set_fact:
-    koji_tags: "{{ diff_package_tags }}"
-  when: diff_package_tags is defined
-
 - include_tasks: git_package_info.yml
 
 - name: Initialize diff_package_changed
@@ -14,7 +9,7 @@
   shell: "{{ diff_package_koji_command }} list-tagged --quiet --latest {{ item }} {{ scl + '-' if scl else '' }}{{ inventory_hostname }} \
     | cut -d' ' -f1"
   register: koji_package_versions
-  with_items: "{{ koji_tags }}"
+  with_items: "{{ diff_package_tags if diff_package_tags is defined else koji_tags }}"
   changed_when: false
 
 - name: "Set koji_package_versions"

--- a/obal/data/roles/setup_sources/defaults/main.yaml
+++ b/obal/data/roles/setup_sources/defaults/main.yaml
@@ -1,2 +1,3 @@
 ---
 setup_sources_annex_options: ""
+setup_sources_skip: false

--- a/tests/fixtures/help/nightly.txt
+++ b/tests/fixtures/help/nightly.txt
@@ -1,4 +1,4 @@
-usage: obal nightly [-h] [-v] [-e EXTRA_VARS] [--skip-koji-whitelist-check]
+usage: obal nightly [-h] [-v] [-e EXTRA_VARS] [--skip-koji-tag-check]
                     [--scratch] [--githash NIGHTLY_GITHASH]
                     [--source NIGHTLY_SOURCEFILES]
                     target [target ...]
@@ -13,9 +13,8 @@ positional arguments:
 optional arguments:
   -h, --help            show this help message and exit
   -v, --verbose         verbose output
-  --skip-koji-whitelist-check
-                        ignore koji whitelist check and release the package
-                        anyway
+  --skip-koji-tag-check
+                        ignore koji tag check and release the package anyway
   --scratch             Set --scratch for scratch builds.
   --githash NIGHTLY_GITHASH
                         Git commit hash to be included in the RPM's release.

--- a/tests/fixtures/help/release.txt
+++ b/tests/fixtures/help/release.txt
@@ -1,4 +1,4 @@
-usage: obal release [-h] [-v] [-e EXTRA_VARS] [--skip-koji-whitelist-check]
+usage: obal release [-h] [-v] [-e EXTRA_VARS] [--skip-koji-tag-check]
                     target [target ...]
 
 This action releases a package to Koji/Brew/Copr
@@ -11,9 +11,8 @@ positional arguments:
 optional arguments:
   -h, --help            show this help message and exit
   -v, --verbose         verbose output
-  --skip-koji-whitelist-check
-                        ignore koji whitelist check and release the package
-                        anyway
+  --skip-koji-tag-check
+                        ignore koji tag check and release the package anyway
 
 advanced arguments:
   -e EXTRA_VARS, --extra-vars EXTRA_VARS

--- a/tests/fixtures/help/scratch.txt
+++ b/tests/fixtures/help/scratch.txt
@@ -1,4 +1,4 @@
-usage: obal scratch [-h] [-v] [-e EXTRA_VARS] [--skip-koji-whitelist-check]
+usage: obal scratch [-h] [-v] [-e EXTRA_VARS] [--skip-koji-tag-check]
                     target [target ...]
 
 Create a scratch build of a package
@@ -11,9 +11,9 @@ positional arguments:
 optional arguments:
   -h, --help            show this help message and exit
   -v, --verbose         verbose output
-  --skip-koji-whitelist-check
-                        ignore koji whitelist check and scratch build the
-                        package anyway
+  --skip-koji-tag-check
+                        ignore koji tag check and scratch build the package
+                        anyway
 
 advanced arguments:
   -e EXTRA_VARS, --extra-vars EXTRA_VARS

--- a/tests/fixtures/mockbin/mockbin
+++ b/tests/fixtures/mockbin/mockbin
@@ -76,7 +76,7 @@ if prog == 'tito':
 
 elif prog in ['koji', 'brew']:
     parser = argparse.ArgumentParser()
-    subparsers = parser.add_subparsers()
+    subparsers = parser.add_subparsers(dest='command')
 
     parser_listpkgs = subparsers.add_parser('list-pkgs')
     parser_listpkgs.add_argument('--tag')
@@ -113,10 +113,19 @@ elif prog in ['koji', 'brew']:
     parser_latest_build.add_argument('pkg')
     parser_latest_build.add_argument('--quiet', action='store_true')
 
+    parser_build = subparsers.add_parser('build')
+    parser_build.add_argument('tag')
+    parser_build.add_argument('pkg')
+    parser_build.add_argument('--scratch', action='store_true')
+
     parser_taskinfo.add_argument('-v', action='store_const', dest='output', const=_FAKE_TASKINFO)
     args = parser.parse_args()
+
     if 'output' in args and args.output:
         print(args.output)
+
+    if args.command == 'build':
+        print('Created task: 1234')
 
 elif prog in ['copr-cli']:
     print({})

--- a/tests/fixtures/testrepo/upstream/package_manifest.yaml
+++ b/tests/fixtures/testrepo/upstream/package_manifest.yaml
@@ -3,7 +3,6 @@ packages:
   vars:
     releasers:
       - dist-git
-    nightly_releaser: dist-git-jenkins
     diff_package_skip: false
     diff_package_type: 'koji'
     diff_package_koji_command: 'koji'
@@ -11,9 +10,7 @@ packages:
       - name: obaltest-nightly-rhel7
         dist: '.el7'
   hosts:
-    hello:
-      nightly_package_tito_releaser_args:
-        - "jenkins_job=hello-master-release"
+    hello: {}
     foo: {}
 
 repoclosures:

--- a/tests/fixtures/testrepo/upstream/packages/hello/hello.spec
+++ b/tests/fixtures/testrepo/upstream/packages/hello/hello.spec
@@ -18,7 +18,7 @@ BuildRequires: gettext
 Requires(post): info
 Requires(preun): info
 
-Obsoletes: goodbye
+Obsoletes: goodbye < 1.0
 
 %description
 The "Hello World" program, done with all bells and whistles of a proper FOSS


### PR DESCRIPTION
The idea here is to move away from relying on tito releasers and whitelists and using package_manifest and koji directly for build tasks. Given this requires transition within a package_manifest I am attempting to build it such that both functionality is supported for some period of time based on available configuration in the package_manifest.