### PR TITLE
Cleans up diff-package output

### DIFF
--- a/obal/data/ansible.cfg
+++ b/obal/data/ansible.cfg
@@ -9,3 +9,4 @@ display_skipped_hosts = false
 roles_path = ./roles/
 library = ./modules
 module_utils = ./module_utils
+deprecation_warnings = False

--- a/obal/data/playbooks/check/check.yaml
+++ b/obal/data/playbooks/check/check.yaml
@@ -1,7 +1,6 @@
 ---
 - hosts:
     - packages
-  serial: 1
   gather_facts: no
   roles:
     - diff_package

--- a/obal/data/roles/diff_package/tasks/koji.yml
+++ b/obal/data/roles/diff_package/tasks/koji.yml
@@ -11,13 +11,20 @@
   with_items: "{{ diff_package_tags }}"
   changed_when: False
 
-- set_fact:
-    diff_package_changed: "{{ not item.stdout.startswith(git_package_version) or diff_package_changed }}"
-  with_items: "{{ koji_package_versions.results }}"
+- name: "Set koji_package_versions"
+  set_fact:
+    koji_package_versions: "{{ koji_package_versions.results | map(attribute='stdout') | list }}"
+  no_log: True
+
+- name: "Calculate diff_package_changed"
+  set_fact:
+    diff_package_changed: "{{ not item.startswith(git_package_version) or diff_package_changed }}"
+  with_items: "{{ koji_package_versions }}"
+  no_log: True
 
 - debug:
     msg:
       - "Git version: {{ git_package_version }}"
-      - "Tagged version: {{ item.stdout }}"
+      - "Tagged version: {{ item }}"
       - "Changed: {{ diff_package_changed }}"
-  with_items: "{{ koji_package_versions.results }}"
+  with_items: "{{ koji_package_versions }}"


### PR DESCRIPTION
This also hides deprecation warnings as they can often be based on the system running the commands and removes the one at a time nature of diff package.

```
ehelms@war foreman-packaging (rpm/develop)$ obal check foreman_nonscl_packages

PLAY [packages] *****************************************************************************************
Wednesday 18 March 2020  15:51:23 -0400 (0:00:00.340)       0:00:00.340 ******* 

TASK [ensure_package : check for package dir] ***********************************************************
ok: [foreman-selinux]
ok: [foreman-bootloaders-redhat]
ok: [foreman-installer]
ok: [foreman-release-scl]
ok: [katello-certs-tools]
ok: [keycloak-httpd-client-install]
ok: [pcp-mmvstatsd]
ok: [katello-selinux]
ok: [puppet-agent-puppet-strings]
ok: [puppet-agent-oauth]
ok: [puppet-agent-rgen]
ok: [puppet-agent-yard]
ok: [rubygem-foreman_maintain]
ok: [rubygem-kafo_parsers]
ok: [rubygem-kafo]
ok: [rubygem-kafo_wizards]
Wednesday 18 March 2020  15:51:24 -0400 (0:00:01.036)       0:00:01.377 ******* 

TASK [spec_file : get spec file] ************************************************************************
ok: [foreman-bootloaders-redhat]
ok: [katello-certs-tools]
ok: [foreman-installer]
ok: [foreman-selinux]
ok: [foreman-release-scl]
ok: [katello-selinux]
ok: [keycloak-httpd-client-install]
ok: [puppet-agent-oauth]
ok: [pcp-mmvstatsd]
ok: [puppet-agent-puppet-strings]
ok: [puppet-agent-rgen]
ok: [puppet-agent-yard]
ok: [rubygem-foreman_maintain]
ok: [rubygem-kafo_parsers]
ok: [rubygem-kafo]
ok: [rubygem-kafo_wizards]
Wednesday 18 March 2020  15:51:25 -0400 (0:00:00.947)       0:00:02.324 ******* 

TASK [spec_file : Set spec file path] *******************************************************************
ok: [foreman-bootloaders-redhat]
ok: [foreman-installer]
ok: [foreman-release-scl]
ok: [foreman-selinux]
ok: [katello-certs-tools]
ok: [katello-selinux]
ok: [keycloak-httpd-client-install]
ok: [pcp-mmvstatsd]
ok: [puppet-agent-oauth]
ok: [puppet-agent-puppet-strings]
ok: [puppet-agent-rgen]
ok: [puppet-agent-yard]
ok: [rubygem-foreman_maintain]
ok: [rubygem-kafo]
ok: [rubygem-kafo_parsers]
ok: [rubygem-kafo_wizards]
Wednesday 18 March 2020  15:51:26 -0400 (0:00:00.160)       0:00:02.484 ******* 
included: /usr/local/lib/python3.7/site-packages/obal/data/roles/diff_package/tasks/koji.yml for foreman-bootloaders-redhat, foreman-installer, foreman-release-scl, foreman-selinux, katello-certs-tools, katello-selinux, keycloak-httpd-client-install, pcp-mmvstatsd, puppet-agent-oauth, puppet-agent-puppet-strings, puppet-agent-rgen, puppet-agent-yard, rubygem-foreman_maintain, rubygem-kafo, rubygem-kafo_parsers, rubygem-kafo_wizards
Wednesday 18 March 2020  15:51:26 -0400 (0:00:00.202)       0:00:02.686 ******* 
included: /usr/local/lib/python3.7/site-packages/obal/data/roles/diff_package/tasks/git_package_info.yml for foreman-bootloaders-redhat, foreman-installer, foreman-release-scl, foreman-selinux, katello-certs-tools, katello-selinux, keycloak-httpd-client-install, pcp-mmvstatsd, puppet-agent-oauth, puppet-agent-puppet-strings, puppet-agent-rgen, puppet-agent-yard, rubygem-foreman_maintain, rubygem-kafo, rubygem-kafo_parsers, rubygem-kafo_wizards
Wednesday 18 March 2020  15:51:26 -0400 (0:00:00.248)       0:00:02.935 ******* 

TASK [diff_package : Get latest package info from git] **************************************************
ok: [foreman-selinux]
ok: [foreman-release-scl]
ok: [foreman-bootloaders-redhat]
ok: [foreman-installer]
ok: [katello-certs-tools]
ok: [katello-selinux]
ok: [puppet-agent-oauth]
ok: [keycloak-httpd-client-install]
ok: [pcp-mmvstatsd]
ok: [puppet-agent-puppet-strings]
ok: [puppet-agent-rgen]
ok: [puppet-agent-yard]
ok: [rubygem-kafo]
ok: [rubygem-foreman_maintain]
ok: [rubygem-kafo_parsers]
ok: [rubygem-kafo_wizards]
Wednesday 18 March 2020  15:51:27 -0400 (0:00:01.009)       0:00:03.944 ******* 

TASK [diff_package : set_fact] **************************************************************************
ok: [foreman-bootloaders-redhat]
ok: [foreman-installer]
ok: [foreman-release-scl]
ok: [foreman-selinux]
ok: [katello-certs-tools]
ok: [katello-selinux]
ok: [keycloak-httpd-client-install]
ok: [pcp-mmvstatsd]
ok: [puppet-agent-oauth]
ok: [puppet-agent-puppet-strings]
ok: [puppet-agent-rgen]
ok: [puppet-agent-yard]
ok: [rubygem-foreman_maintain]
ok: [rubygem-kafo]
ok: [rubygem-kafo_parsers]
ok: [rubygem-kafo_wizards]
Wednesday 18 March 2020  15:51:27 -0400 (0:00:00.159)       0:00:04.103 ******* 

TASK [diff_package : set_fact] **************************************************************************
ok: [foreman-bootloaders-redhat]
ok: [foreman-installer]
ok: [foreman-release-scl]
ok: [foreman-selinux]
ok: [katello-certs-tools]
ok: [katello-selinux]
ok: [keycloak-httpd-client-install]
ok: [pcp-mmvstatsd]
ok: [puppet-agent-oauth]
ok: [puppet-agent-puppet-strings]
ok: [puppet-agent-rgen]
ok: [puppet-agent-yard]
ok: [rubygem-foreman_maintain]
ok: [rubygem-kafo]
ok: [rubygem-kafo_parsers]
ok: [rubygem-kafo_wizards]
Wednesday 18 March 2020  15:51:27 -0400 (0:00:00.159)       0:00:04.262 ******* 

TASK [diff_package : Look up current version of package in koji] ****************************************
ok: [foreman-selinux] => (item=foreman-nightly-nonscl-rhel7)
ok: [foreman-bootloaders-redhat] => (item=foreman-nightly-nonscl-rhel7)
ok: [foreman-installer] => (item=foreman-nightly-nonscl-rhel7)
ok: [foreman-release-scl] => (item=foreman-nightly-nonscl-rhel7)
ok: [katello-certs-tools] => (item=foreman-nightly-nonscl-rhel7)
ok: [katello-selinux] => (item=foreman-nightly-nonscl-rhel7)
ok: [keycloak-httpd-client-install] => (item=foreman-nightly-nonscl-rhel7)
ok: [puppet-agent-oauth] => (item=foreman-nightly-nonscl-rhel7)
ok: [pcp-mmvstatsd] => (item=foreman-nightly-nonscl-rhel7)
ok: [puppet-agent-puppet-strings] => (item=foreman-nightly-nonscl-rhel7)
ok: [puppet-agent-rgen] => (item=foreman-nightly-nonscl-rhel7)
ok: [rubygem-kafo_parsers] => (item=foreman-nightly-nonscl-rhel7)
ok: [rubygem-foreman_maintain] => (item=foreman-nightly-nonscl-rhel7)
ok: [puppet-agent-yard] => (item=foreman-nightly-nonscl-rhel7)
ok: [rubygem-kafo] => (item=foreman-nightly-nonscl-rhel7)
ok: [rubygem-kafo_wizards] => (item=foreman-nightly-nonscl-rhel7)
Wednesday 18 March 2020  15:51:30 -0400 (0:00:02.393)       0:00:06.655 ******* 

TASK [diff_package : Set koji_package_versions] *********************************************************
ok: [foreman-bootloaders-redhat]
ok: [foreman-installer]
ok: [foreman-release-scl]
ok: [foreman-selinux]
ok: [katello-certs-tools]
ok: [katello-selinux]
ok: [keycloak-httpd-client-install]
ok: [pcp-mmvstatsd]
ok: [puppet-agent-oauth]
ok: [puppet-agent-puppet-strings]
ok: [puppet-agent-rgen]
ok: [puppet-agent-yard]
ok: [rubygem-foreman_maintain]
ok: [rubygem-kafo]
ok: [rubygem-kafo_parsers]
ok: [rubygem-kafo_wizards]
Wednesday 18 March 2020  15:51:30 -0400 (0:00:00.172)       0:00:06.827 ******* 

TASK [diff_package : Calculate diff_package_changed] ****************************************************
ok: [foreman-bootloaders-redhat] => (item=None)
ok: [foreman-bootloaders-redhat]
ok: [foreman-installer] => (item=None)
ok: [foreman-installer]
ok: [foreman-release-scl] => (item=None)
ok: [foreman-release-scl]
ok: [foreman-selinux] => (item=None)
ok: [foreman-selinux]
ok: [katello-certs-tools] => (item=None)
ok: [katello-certs-tools]
ok: [katello-selinux] => (item=None)
ok: [katello-selinux]
ok: [keycloak-httpd-client-install] => (item=None)
ok: [keycloak-httpd-client-install]
ok: [pcp-mmvstatsd] => (item=None)
ok: [pcp-mmvstatsd]
ok: [puppet-agent-oauth] => (item=None)
ok: [puppet-agent-oauth]
ok: [puppet-agent-puppet-strings] => (item=None)
ok: [puppet-agent-puppet-strings]
ok: [puppet-agent-rgen] => (item=None)
ok: [puppet-agent-rgen]
ok: [puppet-agent-yard] => (item=None)
ok: [puppet-agent-yard]
ok: [rubygem-foreman_maintain] => (item=None)
ok: [rubygem-foreman_maintain]
ok: [rubygem-kafo] => (item=None)
ok: [rubygem-kafo]
ok: [rubygem-kafo_parsers] => (item=None)
ok: [rubygem-kafo_parsers]
ok: [rubygem-kafo_wizards] => (item=None)
ok: [rubygem-kafo_wizards]
Wednesday 18 March 2020  15:51:30 -0400 (0:00:00.190)       0:00:07.018 ******* 

TASK [diff_package : debug] *****************************************************************************
ok: [foreman-bootloaders-redhat] => (item=foreman-bootloaders-redhat-201901011200-1.el7) => 
  msg:
  - 'Git version: foreman-bootloaders-redhat-201901011200-1'
  - 'Tagged version: foreman-bootloaders-redhat-201901011200-1.el7'
  - 'Changed: False'
ok: [foreman-installer] => (item=foreman-installer-2.1.0-0.1.develop.20200318115444gitbd02fbd.el7) => 
  msg:
  - 'Git version: foreman-installer-2.1.0-0.1.develop'
  - 'Tagged version: foreman-installer-2.1.0-0.1.develop.20200318115444gitbd02fbd.el7'
  - 'Changed: False'
ok: [foreman-release-scl] => (item=foreman-release-scl-7-2.el7) => 
  msg:
  - 'Git version: foreman-release-scl-7-2'
  - 'Tagged version: foreman-release-scl-7-2.el7'
  - 'Changed: False'
ok: [foreman-selinux] => (item=foreman-selinux-2.1.0-0.1.develop.20200213185945git6755e39.el7) => 
  msg:
  - 'Git version: foreman-selinux-2.1.0-0.1.develop'
  - 'Tagged version: foreman-selinux-2.1.0-0.1.develop.20200213185945git6755e39.el7'
  - 'Changed: False'
ok: [katello-certs-tools] => (item=katello-certs-tools-2.6.0-1.el7) => 
  msg:
  - 'Git version: katello-certs-tools-2.6.0-1'
  - 'Tagged version: katello-certs-tools-2.6.0-1.el7'
  - 'Changed: False'
ok: [katello-selinux] => (item=katello-selinux-3.1.1-1.el7) => 
  msg:
  - 'Git version: katello-selinux-3.1.1-1'
  - 'Tagged version: katello-selinux-3.1.1-1.el7'
  - 'Changed: False'
ok: [keycloak-httpd-client-install] => (item=keycloak-httpd-client-install-1.2.2-1.el7) => 
  msg:
  - 'Git version: keycloak-httpd-client-install-1.2.2-1'
  - 'Tagged version: keycloak-httpd-client-install-1.2.2-1.el7'
  - 'Changed: False'
ok: [pcp-mmvstatsd] => (item=pcp-mmvstatsd-0.4-2.el7) => 
  msg:
  - 'Git version: pcp-mmvstatsd-0.4-2'
  - 'Tagged version: pcp-mmvstatsd-0.4-2.el7'
  - 'Changed: False'
ok: [puppet-agent-oauth] => (item=puppet-agent-oauth-0.5.1-3.el7) => 
  msg:
  - 'Git version: puppet-agent-oauth-0.5.1-3'
  - 'Tagged version: puppet-agent-oauth-0.5.1-3.el7'
  - 'Changed: False'
ok: [puppet-agent-puppet-strings] => (item=puppet-agent-puppet-strings-2.3.0-1.el7) => 
  msg:
  - 'Git version: puppet-agent-puppet-strings-2.3.0-1'
  - 'Tagged version: puppet-agent-puppet-strings-2.3.0-1.el7'
  - 'Changed: False'
ok: [puppet-agent-rgen] => (item=puppet-agent-rgen-0.8.2-1.el7) => 
  msg:
  - 'Git version: puppet-agent-rgen-0.8.2-1'
  - 'Tagged version: puppet-agent-rgen-0.8.2-1.el7'
  - 'Changed: False'
ok: [puppet-agent-yard] => (item=puppet-agent-yard-0.9.5-1.el7) => 
  msg:
  - 'Git version: puppet-agent-yard-0.9.5-1'
  - 'Tagged version: puppet-agent-yard-0.9.5-1.el7'
  - 'Changed: False'
ok: [rubygem-foreman_maintain] => (item=rubygem-foreman_maintain-0.6.2-1.el7) => 
  msg:
  - 'Git version: rubygem-foreman_maintain-0.6.2-1'
  - 'Tagged version: rubygem-foreman_maintain-0.6.2-1.el7'
  - 'Changed: False'
ok: [rubygem-kafo] => (item=rubygem-kafo-4.0.1-1.el7) => 
  msg:
  - 'Git version: rubygem-kafo-4.0.1-1'
  - 'Tagged version: rubygem-kafo-4.0.1-1.el7'
  - 'Changed: False'
ok: [rubygem-kafo_parsers] => (item=rubygem-kafo_parsers-1.0.0-1.el7) => 
  msg:
  - 'Git version: rubygem-kafo_parsers-1.0.0-1'
  - 'Tagged version: rubygem-kafo_parsers-1.0.0-1.el7'
  - 'Changed: False'
ok: [rubygem-kafo_wizards] => (item=rubygem-kafo_wizards-0.0.1-2.el7) => 
  msg:
  - 'Git version: rubygem-kafo_wizards-0.0.1-2'
  - 'Tagged version: rubygem-kafo_wizards-0.0.1-2.el7'
  - 'Changed: False'
Wednesday 18 March 2020  15:51:30 -0400 (0:00:00.184)       0:00:07.203 ******* 

PLAY RECAP **********************************************************************************************
foreman-bootloaders-redhat : ok=12   changed=0    unreachable=0    failed=0    skipped=1    rescued=0    ignored=0   
foreman-installer          : ok=12   changed=0    unreachable=0    failed=0    skipped=1    rescued=0    ignored=0   
foreman-release-scl        : ok=12   changed=0    unreachable=0    failed=0    skipped=1    rescued=0    ignored=0   
foreman-selinux            : ok=12   changed=0    unreachable=0    failed=0    skipped=1    rescued=0    ignored=0   
katello-certs-tools        : ok=12   changed=0    unreachable=0    failed=0    skipped=1    rescued=0    ignored=0   
katello-selinux            : ok=12   changed=0    unreachable=0    failed=0    skipped=1    rescued=0    ignored=0   
keycloak-httpd-client-install : ok=12   changed=0    unreachable=0    failed=0    skipped=1    rescued=0    ignored=0   
pcp-mmvstatsd              : ok=12   changed=0    unreachable=0    failed=0    skipped=1    rescued=0    ignored=0   
puppet-agent-oauth         : ok=12   changed=0    unreachable=0    failed=0    skipped=1    rescued=0    ignored=0   
puppet-agent-puppet-strings : ok=12   changed=0    unreachable=0    failed=0    skipped=1    rescued=0    ignored=0   
puppet-agent-rgen          : ok=12   changed=0    unreachable=0    failed=0    skipped=1    rescued=0    ignored=0   
puppet-agent-yard          : ok=12   changed=0    unreachable=0    failed=0    skipped=1    rescued=0    ignored=0   
rubygem-foreman_maintain   : ok=12   changed=0    unreachable=0    failed=0    skipped=1    rescued=0    ignored=0   
rubygem-kafo               : ok=12   changed=0    unreachable=0    failed=0    skipped=1    rescued=0    ignored=0   
rubygem-kafo_parsers       : ok=12   changed=0    unreachable=0    failed=0    skipped=1    rescued=0    ignored=0   
rubygem-kafo_wizards       : ok=12   changed=0    unreachable=0    failed=0    skipped=1    rescued=0    ignored=0   
```