### PR TITLE
Shift koji_tags to a dictionary

### DIFF
--- a/obal/data/roles/diff_package/tasks/koji.yml
+++ b/obal/data/roles/diff_package/tasks/koji.yml
@@ -1,7 +1,8 @@
 ---
 - set_fact:
-    koji_tags: "{{ diff_package_tags }}"
+    koji_tags: "{{ koji_tags| default({}) | combine({ item: {} }) }}"
   when: diff_package_tags is defined
+  loop: "{{ diff_package_tags }}"
 
 - include_tasks: git_package_info.yml
 
@@ -9,10 +10,15 @@
     diff_package_changed: False
 
 - name: 'Look up current version of package in {{ diff_package_koji_command }}'
-  shell: "{{ diff_package_koji_command }} list-tagged --quiet --latest {{ item }} {{ scl + '-' if scl else '' }}{{ inventory_hostname }} \
-    | cut -d' ' -f1"
+  shell: >
+    {{ diff_package_koji_command }} list-tagged
+    --quiet
+    --latest
+    {{ item.key }}
+    {{ item.value.scl + '-' if item.value.scl is defined else '' }}{{ inventory_hostname }}
+    | cut -d' ' -f1
   register: koji_package_versions
-  with_items: "{{ koji_tags }}"
+  loop: "{{ koji_tags|dict2items }}"
   changed_when: False
 
 - name: "Set koji_package_versions"
@@ -22,8 +28,8 @@
 
 - name: "Calculate diff_package_changed"
   set_fact:
-    diff_package_changed: "{{ not item.startswith(git_package_version) or diff_package_changed }}"
-  with_items: "{{ koji_package_versions }}"
+    diff_package_changed: "{{ git_package_version not in item or diff_package_changed }}"
+  loop: "{{ koji_package_versions }}"
   no_log: True
 
 - debug:
@@ -31,4 +37,4 @@
       - "Git version: {{ git_package_version }}"
       - "Tagged version: {{ item }}"
       - "Changed: {{ diff_package_changed }}"
-  with_items: "{{ koji_package_versions }}"
+  loop: "{{ koji_package_versions }}"

--- a/obal/data/roles/package_variables/defaults/main.yml
+++ b/obal/data/roles/package_variables/defaults/main.yml
@@ -1,3 +1,3 @@
 ---
 package_base_dir: "packages/"
-koji_tags: []
+koji_tags: {}

--- a/tests/fixtures/testrepo/downstream/package_manifest.yaml
+++ b/tests/fixtures/testrepo/downstream/package_manifest.yaml
@@ -4,13 +4,13 @@ packages:
     diff_package_skip: false
     diff_package_type: 'koji'
     diff_package_koji_command: 'brew'
-    scl: tfm
     build_package_koji_command: 'brew'
     build_package_build_system: 'koji'
     releasers:
       - obaltest-dist-git-rhel-7
-    diff_package_tags:
-      - obaltest-6.3.0-rhel-7-candidate
+    koji_tags:
+      obaltest-6.3.0-rhel-7-candidate:
+        scl: tfm
     source_server: http://ftp.gnu.org/gnu/hello/
   hosts:
     hello:

--- a/tests/fixtures/testrepo/upstream/package_manifest.yaml
+++ b/tests/fixtures/testrepo/upstream/package_manifest.yaml
@@ -7,9 +7,9 @@ packages:
     diff_package_skip: false
     diff_package_type: 'koji'
     diff_package_koji_command: 'koji'
-    scl: tfm
-    diff_package_tags:
-      - obaltest-nightly-rhel7
+    koji_tags:
+      obaltest-nightly-rhel7:
+        scl: tfm
   hosts:
     hello:
       nightly_package_tito_releaser_args:

--- a/tests/fixtures/testrepo/upstream_bad_changelog/package_manifest.yaml
+++ b/tests/fixtures/testrepo/upstream_bad_changelog/package_manifest.yaml
@@ -6,9 +6,9 @@ packages:
     diff_package_skip: false
     diff_package_type: 'koji'
     diff_package_koji_command: 'koji'
-    scl: tfm
-    diff_package_tags:
-      - obaltest-nightly-rhel7
+    koji_tags:
+      obaltest-nightly-rhel7:
+        scl: tfm
   hosts:
     hello: {}
 

--- a/tests/fixtures/testrepo/upstream_with_epoch/package_manifest.yaml
+++ b/tests/fixtures/testrepo/upstream_with_epoch/package_manifest.yaml
@@ -7,9 +7,8 @@ packages:
     diff_package_skip: false
     diff_package_type: 'koji'
     diff_package_koji_command: 'koji'
-    scl: tfm
-    diff_package_tags:
-      - obaltest-nightly-rhel7
+    koji_tags:
+      obaltest-nightly-rhel7: {}
   hosts:
     hello:
       nightly_package_tito_releaser_args:


### PR DESCRIPTION
This would fix issues with scl and non-scl tags:

```
k: [rubygem-kafo] => (item=tfm-rubygem-kafo-4.1.0-3.el7) => 
  msg:
  - 'Git version: rubygem-kafo-4.1.0-3'
  - 'Tagged version: tfm-rubygem-kafo-4.1.0-3.el7'
  - 'Changed: True'
ok: [rubygem-kafo] => (item=rubygem-kafo-4.1.0-3.el8) => 
  msg:
  - 'Git version: rubygem-kafo-4.1.0-3'
  - 'Tagged version: rubygem-kafo-4.1.0-3.el8'
  - 'Changed: True'
```

I think a follow on to this should be to turn this into a module for cleaner output and handling.