### PR TITLE
Add modules and command to verify a tag against local content

### DIFF
--- a/obal/data/modules/koji_find_tags.py
+++ b/obal/data/modules/koji_find_tags.py
@@ -1,0 +1,29 @@
+"""
+Find all defined Koji tags in inventory
+"""
+
+from ansible.module_utils.basic import AnsibleModule
+
+def main():
+    """
+    Find all defined Koji tags in inventory
+    """
+    module = AnsibleModule(
+        argument_spec=dict(
+            packages=dict(type='dict', required=True)
+        )
+    )
+
+    packages = module.params['packages']
+
+    tags = set()
+
+    for attributes in packages.values():
+        if 'koji_tags' in attributes:
+            tags.update(tag['name'] for tag in attributes['koji_tags'])
+
+    module.exit_json(changed=False, tags=sorted(tags))
+
+
+if __name__ == '__main__':
+    main()

--- a/obal/data/modules/koji_verify_tag.py
+++ b/obal/data/modules/koji_verify_tag.py
@@ -1,0 +1,68 @@
+"""
+Verify packages against a tag in Koji
+"""
+
+import os
+import subprocess
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.obal import get_specfile_name # pylint:disable=import-error,no-name-in-module
+from ansible.module_utils.koji_wrapper import koji # pylint:disable=import-error,no-name-in-module
+
+def main():
+    """
+    Verify packages against a tag in Koji
+    """
+    module = AnsibleModule(
+        argument_spec=dict(
+            packages=dict(type='dict', required=True),
+            tag=dict(type='str', required=True),
+            directory=dict(type='str', required=True),
+            koji_executable=dict(type='str', require=False, default='koji')
+        )
+    )
+
+    packages_for_tag = set()
+
+    for (package, attributes) in module.params['packages'].items():
+        tag = None
+
+        if 'koji_tags' in attributes:
+            for koji_tag in attributes['koji_tags']:
+                if module.params['tag'] == koji_tag['name']:
+                    tag = koji_tag
+
+            if tag and 'package_base_dir' in attributes:
+                specfile = os.path.join(attributes['package_base_dir'], package, "{}.spec".format(package))
+                scl = tag.get('scl')
+                name = get_specfile_name(os.path.join(module.params['directory'], specfile), scl)
+                packages_for_tag.add(name)
+
+    try:
+        command = ['list-pkgs', '--quiet', '--tag', module.params['tag']]
+        koji_output = koji(
+            command,
+            executable=module.params['koji_executable']
+        )
+
+        packages_in_koji = {item.split(' ', 1)[0] for item in koji_output.split("\n") if item}
+
+    except subprocess.CalledProcessError as error:
+        module.fail_json(changed=False, msg=error.output)
+
+    missing_in_koji = packages_for_tag - packages_in_koji
+    missing_in_git = packages_in_koji - packages_for_tag
+
+    if missing_in_koji or missing_in_git:
+        module.fail_json(
+            changed=True,
+            msg="Package differences found",
+            missing_in_git=sorted(missing_in_git),
+            missing_in_koji=sorted(missing_in_koji)
+        )
+    else:
+        module.exit_json(changed=False)
+
+
+if __name__ == '__main__':
+    main()

--- a/obal/data/playbooks/verify-koji-tag/metadata.obal.yaml
+++ b/obal/data/playbooks/verify-koji-tag/metadata.obal.yaml
@@ -1,0 +1,5 @@
+help: Verify packages against a Koji tag
+variables:
+  tag:
+    parameter: tag
+    help: Koji tag to verify against

--- a/obal/data/playbooks/verify-koji-tag/verify-koji-tag.yaml
+++ b/obal/data/playbooks/verify-koji-tag/verify-koji-tag.yaml
@@ -1,0 +1,6 @@
+---
+- hosts:
+    - localhost
+  gather_facts: false
+  roles:
+    - verify_koji_tag

--- a/obal/data/roles/verify_koji_tag/defaults/main.yml
+++ b/obal/data/roles/verify_koji_tag/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+verify_koji_tag_all: false

--- a/obal/data/roles/verify_koji_tag/tasks/all.yaml
+++ b/obal/data/roles/verify_koji_tag/tasks/all.yaml
@@ -1,0 +1,10 @@
+---
+- name: Find all tags
+  koji_find_tags:
+    packages: "{{ hostvars }}"
+  register: tags
+
+- include_tasks: "verify.yaml"
+  loop: "{{ tags.tags }}"
+  loop_control:
+    loop_var: tag_name

--- a/obal/data/roles/verify_koji_tag/tasks/main.yaml
+++ b/obal/data/roles/verify_koji_tag/tasks/main.yaml
@@ -1,0 +1,8 @@
+---
+- when: tag != 'all'
+  include_tasks: "verify.yaml"
+  vars:
+    tag_name: "{{ tag }}"
+
+- when: tag == 'all'
+  include_tasks: "all.yaml"

--- a/obal/data/roles/verify_koji_tag/tasks/verify.yaml
+++ b/obal/data/roles/verify_koji_tag/tasks/verify.yaml
@@ -1,0 +1,22 @@
+---
+- name: Verify tag
+  koji_verify_tag:
+    tag: "{{ tag_name }}"
+    packages: "{{ hostvars }}"
+    directory: "{{ lookup('env', 'PWD') }}"
+    koji_executable: "{{ koji_executable|default('koji') }}"
+  register: missing
+
+- name: "Packages in Koji but not in git for {{ tag_name }}"
+  debug:
+    msg: "{{ missing.missing_in_git }}"
+  when:
+    - missing is changed
+    - missing.missing_in_git|length > 0
+
+- name: "Packages missing in Koji for {{ tag_name }}"
+  debug:
+    msg: "{{ missing.missing_in_koji }}"
+  when:
+    - missing is changed
+    - missing.missing_in_koji|length > 0

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ setup(
 
     packages=find_packages(exclude=['contrib', 'docs', 'tests']),
 
-    install_requires=['ansible >= 2.5', 'obsah'],
+    install_requires=['ansible >= 2.5', 'obsah >= 0.0.2'],
 
     extras_require={
         'argcomplete': ['argcomplete'],

--- a/tests/fixtures/help/verify-koji-tag.txt
+++ b/tests/fixtures/help/verify-koji-tag.txt
@@ -1,0 +1,15 @@
+usage: obal verify-koji-tag [-h] [-v] [-e EXTRA_VARS] tag
+
+Verify packages against a Koji tag
+
+positional arguments:
+  tag                   Koji tag to verify against
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -v, --verbose         verbose output
+
+advanced arguments:
+  -e EXTRA_VARS, --extra-vars EXTRA_VARS
+                        set additional variables as key=value or YAML/JSON, if
+                        filename prepend with @

--- a/tests/fixtures/testrepo/upstream/package_manifest.yaml
+++ b/tests/fixtures/testrepo/upstream/package_manifest.yaml
@@ -10,6 +10,8 @@ packages:
     koji_tags:
       - name: obaltest-nightly-rhel7
         dist: '.el7'
+      - name: obaltest-nightly-el8
+        dist: '.el8'
   hosts:
     hello:
       nightly_package_tito_releaser_args:

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -129,6 +129,8 @@ def test_obal_check_upstream_hello():
     expected_log = [
         "koji buildinfo hello-2.10-2.el7",
         "koji latest-build --quiet obaltest-nightly-rhel7 hello",
+        "koji buildinfo hello-2.10-2.el8",
+        "koji latest-build --quiet obaltest-nightly-el8 hello"
     ]
     assert_mockbin_log(expected_log)
 
@@ -169,6 +171,9 @@ def test_obal_scratch_with_koji_upstream_hello():
         "koji build obaltest-nightly-rhel7 /tmp/SRPMs/hello-2.10-2.src.rpm --scratch",
         "koji watch-task 1234",
         "koji taskinfo -v 1234",
+        "koji build obaltest-nightly-el8 /tmp/SRPMs/hello-2.10-2.src.rpm --scratch",
+        "koji watch-task 1234",
+        "koji taskinfo -v 1234",
     ]
     assert_mockbin_log(expected_log)
     assert os.path.exists('/tmp/SRPMs/hello-2.10-2.src.rpm')
@@ -181,7 +186,8 @@ def test_obal_scratch_with_koji_upstream_hello_nowait():
     assert os.path.exists('packages/hello/hello-2.10.tar.gz')
 
     expected_log = [
-        "koji build obaltest-nightly-rhel7 /tmp/SRPMs/hello-2.10-2.src.rpm --scratch"
+        "koji build obaltest-nightly-rhel7 /tmp/SRPMs/hello-2.10-2.src.rpm --scratch",
+        "koji build obaltest-nightly-el8 /tmp/SRPMs/hello-2.10-2.src.rpm --scratch"
     ]
     assert_mockbin_log(expected_log)
     assert os.path.exists('/tmp/SRPMs/hello-2.10-2.src.rpm')
@@ -197,6 +203,12 @@ def test_obal_release_with_koji_upstream_hello():
         "koji latest-build --quiet obaltest-nightly-rhel7 hello",
         "koji build obaltest-nightly-rhel7 /tmp/SRPMs/hello-2.10-2.src.rpm",
         "koji watch-task 1234",
+        "koji taskinfo -v 1234",
+        "koji buildinfo hello-2.10-2.el8",
+        "koji latest-build --quiet obaltest-nightly-el8 hello",
+        "koji latest-build --quiet obaltest-nightly-el8 hello",
+        "koji build obaltest-nightly-el8 /tmp/SRPMs/hello-2.10-2.src.rpm",
+        "koji watch-task 1234",
         "koji taskinfo -v 1234"
     ]
     assert_mockbin_log(expected_log)
@@ -209,7 +221,13 @@ def test_obal_release_with_koji_upstream_existing_build():
     expected_log = [
         "koji buildinfo package-with-existing-build-1.0-1.el7",
         "koji latest-build --quiet obaltest-nightly-rhel7 package-with-existing-build",
-        "koji tag-build obaltest-nightly-rhel7 package-with-existing-build-1.0-1.el7"
+        "koji tag-build obaltest-nightly-rhel7 package-with-existing-build-1.0-1.el7",
+        "koji buildinfo package-with-existing-build-1.0-1.el8",
+        "koji latest-build --quiet obaltest-nightly-el8 package-with-existing-build",
+        "koji latest-build --quiet obaltest-nightly-el8 package-with-existing-build",
+        "koji build obaltest-nightly-el8 /tmp/SRPMs/package-with-existing-build-1.0-1.src.rpm",
+        "koji watch-task 1234",
+        "koji taskinfo -v 1234"
     ]
     assert_mockbin_log(expected_log)
 
@@ -221,7 +239,14 @@ def test_obal_release_with_koji_upstream_whitelist_check():
     expected_log = [
         "koji buildinfo package-with-existing-build-1.0-1.el7",
         "koji latest-build --quiet obaltest-nightly-rhel7 package-with-existing-build",
-        "koji tag-build obaltest-nightly-rhel7 package-with-existing-build-1.0-1.el7"
+        "koji tag-build obaltest-nightly-rhel7 package-with-existing-build-1.0-1.el7",
+        "koji buildinfo package-with-existing-build-1.0-1.el8",
+        "koji latest-build --quiet obaltest-nightly-el8 package-with-existing-build",
+        "koji list-pkgs --tag obaltest-nightly-el8 --package package-with-existing-build --quiet",
+        "koji latest-build --quiet obaltest-nightly-el8 package-with-existing-build",
+        "koji build obaltest-nightly-el8 /tmp/SRPMs/package-with-existing-build-1.0-1.src.rpm",
+        "koji watch-task 1234",
+        "koji taskinfo -v 1234"
     ]
     assert_mockbin_log(expected_log)
 
@@ -235,6 +260,8 @@ def test_obal_release_upstream_hello():
     expected_log = [
         "koji buildinfo hello-2.10-2.el7",
         "koji latest-build --quiet obaltest-nightly-rhel7 hello",
+        "koji buildinfo hello-2.10-2.el8",
+        "koji latest-build --quiet obaltest-nightly-el8 hello",
         "tito release --yes dist-git",
         "koji watch-task 1234",
         "koji taskinfo -v 1234",
@@ -267,7 +294,9 @@ def test_obal_release_upstream_hello_nowait():
     expected_log = [
         "koji buildinfo hello-2.10-2.el7",
         "koji latest-build --quiet obaltest-nightly-rhel7 hello",
-        "tito release --yes dist-git"
+        "koji buildinfo hello-2.10-2.el8",
+        "koji latest-build --quiet obaltest-nightly-el8 hello",
+        "tito release --yes dist-git",
     ]
     assert_mockbin_log(expected_log)
 
@@ -281,6 +310,8 @@ def test_obal_release_upstream_hello_waitrepo():
     expected_log = [
         "koji buildinfo hello-2.10-2.el7",
         "koji latest-build --quiet obaltest-nightly-rhel7 hello",
+        "koji buildinfo hello-2.10-2.el8",
+        "koji latest-build --quiet obaltest-nightly-el8 hello",
         "tito release --yes dist-git",
         "koji watch-task 1234",
         "koji taskinfo -v 1234",
@@ -732,5 +763,24 @@ def test_obal_mock():
 
     expected_log = [
         "mock --recurse --chain -r mock/el7.cfg --localrepo {pwd}/mock_builds SRPMs/foo-1.0-1.src.rpm SRPMs/hello-2.10-2.src.rpm"
+    ]
+    assert_mockbin_log(expected_log)
+
+
+@obal_cli_test(repotype='upstream')
+def test_obal_verify_tag():
+    assert_obal_success(['verify-koji-tag', 'obaltest-nightly-rhel7'])
+
+    expected_log = ['koji list-pkgs --quiet --tag obaltest-nightly-rhel7']
+    assert_mockbin_log(expected_log)
+
+
+@obal_cli_test(repotype='upstream')
+def test_obal_verify_tag_all():
+    assert_obal_success(['verify-koji-tag', 'all'])
+
+    expected_log = [
+        'koji list-pkgs --quiet --tag obaltest-nightly-el8',
+        'koji list-pkgs --quiet --tag obaltest-nightly-rhel7'
     ]
     assert_mockbin_log(expected_log)

--- a/tests/test_playbooks.py
+++ b/tests/test_playbooks.py
@@ -20,7 +20,7 @@ def playbook(request):
 
 
 def test_takes_target_argument(playbook):
-    expected = playbook.name not in ('setup', 'cleanup-copr')
+    expected = playbook.name not in ('setup', 'cleanup-copr', 'verify-koji-tag')
     assert playbook.takes_target_parameter == expected
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,7 @@ deps =
 commands =
     check-manifest --ignore tox.ini,.ansible-lint,tests*,tests/**,docs*,docs/**,*/**/*.pyc,*/**/__pycache__,.yamllint
     python setup.py check -m -s
-    pytest -v -n 4 --flakes --pylint --pylint-rcfile={toxinidir}/.pylintrc --cov=obal --cov-report term --cov-report xml --boxed {posargs}
+    pytest -vv -n 4 --flakes --pylint --pylint-rcfile={toxinidir}/.pylintrc --cov=obal --cov-report term --cov-report xml --boxed {posargs}
     - coveralls
 
 [flake8]


### PR DESCRIPTION
Allows checking if what is local is in the tag on Koji and vice versa.

```
obal verify-tag --tag foreman-nightly-rhel7
obal verify-tag --all
```

@ekohl This would implement some of the gaps you requested