### PR TITLE
Use repoclosure --best option

### DIFF
--- a/obal/data/roles/repoclosure/tasks/repoclosure.yml
+++ b/obal/data/roles/repoclosure/tasks/repoclosure.yml
@@ -32,6 +32,7 @@
             --config {{ temp_directory.path }}/{{ config_filename }}
             --refresh
             --newest
+            --best
             --check {{ repoclosure_target_repos_all | join(' --check ') }}
             {{ '--repofrompath=downloaded_rpms,./downloaded_rpms/'+dist if repoclosure_use_downloaded_rpms else '' }}
             {{ additional_repos | join(' ') }}


### PR DESCRIPTION
The --best option is needed to ensure that packages are checked
across multiple repositories specified via --check.