### PR TITLE
Clean up chdir context manager

### DIFF
--- a/obal/data/module_utils/obal.py
+++ b/obal/data/module_utils/obal.py
@@ -2,8 +2,6 @@
 Ansible module helper functions for obal modules
 """
 import subprocess
-import os
-from contextlib import contextmanager
 
 
 def specfile_macro_lookup(specfile, macro_str, scl=None, dist=None, macros=None):
@@ -77,17 +75,3 @@ def get_whitelist_status(build_command, tag, package):
     ]
     retcode = subprocess.call(cmd)
     return retcode == 0
-
-
-@contextmanager
-def chdir(directory):
-    """
-    Change the directory in a context manager. Automatically switches back even if an exception
-    occurs.
-    """
-    old = os.getcwd()
-    os.chdir(directory)
-    try:
-        yield
-    finally:
-        os.chdir(old)

--- a/obal/data/module_utils/tito_wrapper.py
+++ b/obal/data/module_utils/tito_wrapper.py
@@ -3,12 +3,9 @@ A tito wrapper
 """
 from subprocess import STDOUT, check_output
 
-from ansible.module_utils.obal import chdir # pylint:disable=import-error,no-name-in-module
-
 
 def tito(command, directory):
     """
     Run a tito command
     """
-    with chdir(directory):
-        return check_output(command, stderr=STDOUT, universal_newlines=True)
+    return check_output(command, stderr=STDOUT, universal_newlines=True, cwd=directory)

--- a/obal/data/modules/srpm.py
+++ b/obal/data/modules/srpm.py
@@ -5,10 +5,25 @@ Build SRPM
 import shutil
 import os
 import subprocess
+from contextlib import contextmanager
 from tempfile import mkdtemp
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.obal import chdir # pylint:disable=import-error,no-name-in-module
+
+
+@contextmanager
+def chdir(directory):
+    """
+    Change the directory in a context manager. Automatically switches back even if an exception
+    occurs.
+    """
+    old = os.getcwd()
+    os.chdir(directory)
+    try:
+        yield
+    finally:
+        os.chdir(old)
+
 
 def run_command(command):
     """


### PR DESCRIPTION
This keeps the context manager for srpm because it's generally easier to read than to pass cwd everywhere. In the case of tito, there is no readability benefit. Quite the opposite.