### PR TITLE
Fixes #271: Switch diff_package to calculate based on name-version-re…

### DIFF
--- a/obal/data/module_utils/obal.py
+++ b/obal/data/module_utils/obal.py
@@ -60,8 +60,13 @@ def get_specfile_name(specfile, scl=None):
 
 
 def get_specfile_nevr(specfile, scl=None, dist=None, macros=None):
-    """get the name from the specfile"""
+    """get the name, epoch, version and release from the specfile"""
     return specfile_macro_lookup(specfile, '%{nevr}', scl=scl, dist=dist, macros=macros)
+
+
+def get_specfile_nvr(specfile, scl=None, dist=None, macros=None):
+    """get the name, version and release from the specfile"""
+    return specfile_macro_lookup(specfile, '%{nvr}', scl=scl, dist=dist, macros=macros)
 
 
 def get_whitelist_status(build_command, tag, package):

--- a/obal/data/modules/check_koji_build.py
+++ b/obal/data/modules/check_koji_build.py
@@ -12,13 +12,13 @@ def main():
     module = AnsibleModule(
         argument_spec=dict(
             tag=dict(type='str', required=False),
-            nevr=dict(type='str', required=True),
+            nvr=dict(type='str', required=True),
             package=dict(type='str', required=True),
             koji_executable=dict(type='str', required=False)
         )
     )
 
-    nevr = module.params['nevr']
+    nvr = module.params['nvr']
     tag = module.params['tag']
     package = module.params['package']
     koji_executable = module.params['koji_executable']
@@ -29,9 +29,9 @@ def main():
             build = koji(command, koji_executable)
             build = build.split(' ')[0]
 
-            module.exit_json(changed=False, tagged_version=build, exists=(nevr == build))
+            module.exit_json(changed=False, tagged_version=build, exists=(nvr == build))
         else:
-            command = ['buildinfo', nevr]
+            command = ['buildinfo', nvr]
             output = koji(command, koji_executable)
             exists = 'No such build' not in output
 

--- a/obal/data/modules/rpm_nvr.py
+++ b/obal/data/modules/rpm_nvr.py
@@ -1,0 +1,38 @@
+"""
+Calculate name-version-release for an RPM package
+"""
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.obal import get_specfile_nvr, get_specfile_name # pylint:disable=import-error,no-name-in-module
+
+
+def main():
+    """
+    Calculate name-version-release for a specfile
+    """
+    module = AnsibleModule(
+        argument_spec=dict(
+            spec_file=dict(type='str', required=True),
+            scl=dict(type='str', required=False),
+            dist=dict(type='str', required=False),
+            macros=dict(type='dict', required=False, default={})
+        )
+    )
+
+    nvr = get_specfile_nvr(
+        module.params['spec_file'],
+        scl=module.params['scl'],
+        dist=module.params['dist'],
+        macros=module.params['macros']
+    )
+
+    name = get_specfile_name(
+        module.params['spec_file'],
+        scl=module.params['scl']
+    )
+
+    module.exit_json(changed=False, nvr=nvr, name=name)
+
+
+if __name__ == '__main__':
+    main()

--- a/obal/data/roles/diff_package/tasks/koji_tag.yml
+++ b/obal/data/roles/diff_package/tasks/koji_tag.yml
@@ -1,17 +1,17 @@
 ---
 - name: Find local NEVR for package
-  rpm_nevr:
+  rpm_nvr:
     spec_file: "{{ spec_file_path }}"
     scl: "{{ tag.scl | default(omit) }}"
     dist: "{{ tag.dist | default(omit) }}"
     macros: "{{ tag.macros | default(omit) }}"
-  register: package_nevr
+  register: package_nvr
 
 - name: Verify package build exists for tag
   check_koji_build:
     tag: "{{ tag.name }}"
-    nevr: "{{ package_nevr.nevr }}"
-    package: "{{ package_nevr.name }}"
+    nvr: "{{ package_nvr.nvr }}"
+    package: "{{ package_nvr.name }}"
     koji_executable: "{{ koji_executable|default('koji') }}"
   register: build_exists
 
@@ -22,6 +22,6 @@
 - debug:
     msg:
       - "Tag: {{ tag.name }}"
-      - "Git version: {{ package_nevr.nevr }}"
+      - "Git version: {{ package_nvr.nvr }}"
       - "Tagged version: {{ build_exists.tagged_version }}"
       - "Build Exists: {{ build_exists.exists }}"


### PR DESCRIPTION
…lease

Koji does not report the epoch when looking up package information
so any comparison against a specfile will fail for packages with
an epoch. Given epoch's almost never change, this switches the
diff package check to calculate it based on name-version-release.