### PR TITLE
uncomment prerelease definitions if present

### DIFF
--- a/obal/data/roles/update_spec_file/tasks/main.yml
+++ b/obal/data/roles/update_spec_file/tasks/main.yml
@@ -20,6 +20,13 @@
     - '%global mainver'
   when: version is defined
 
+- name: 'Allow prerelease in specfile'
+  replace:
+    path: "{{ spec_file_path }}"
+    regexp: '^#(global prerelease.*)$'
+    replace: '%\1'
+  when: prerelease is defined
+
 - name: 'Bump prerelease in specfile'
   replace:
     path: "{{ spec_file_path }}"


### PR DESCRIPTION
this allows for packages that aren't *usually* built as nightly, to be
built nightly on demand