### PR TITLE
Add srpm source location

### DIFF
--- a/obal/data/roles/build_srpm/tasks/main.yaml
+++ b/obal/data/roles/build_srpm/tasks/main.yaml
@@ -4,6 +4,8 @@
     package: "{{ inventory_dir }}/{{ package_base_dir }}/{{ inventory_hostname }}"
     output: "{{ build_srpm_output_dir }}"
     scl: "{{ scl | default(omit) }}"
+    source_location: "{{ source_location | default(omit) }}"
+    source_system: "{{ source_system | default(omit) }}"
   register: srpm_build
 
 - name: 'Built srpm path'


### PR DESCRIPTION
This fills a gap in the srpm.py module that was added a few months back. A source location and source type can now be specified that will download sources into the buildroot. This mimcs the behavior that tito used to provide in this area and is focused on supporting our primary use of downloading nightly sources from Jenkins. This will require changes to the package manifest to support it:

```
    foreman:
      releasers:
        - "{{ nightly_releaser }}"
      build_package_tito_releaser_args: "{{ nightly_package_tito_releaser_args }}"
      nightly_package_tito_releaser_args:
        - "jenkins_job=foreman-develop-source-release"
        - "jenkins_url=https://ci.theforeman.org"
      build_package_tito_builder: "tito.builder.FetchBuilder"
      source_location: https://ci.theforeman.org/job/foreman-develop-source-release
      source_system: jenkins
```

Note the last two new parameters. I am not sold on the naming convention of the variables, so feel free to offer new ideas. The tito arguments will have to remain for a period of time as those are still used by the koji build functionality (https://github.com/theforeman/obal/pull/230 aims to close that gap).

This is built on top of https://github.com/theforeman/obal/pull/278 which touches the same file.