### PR TITLE
Return the changelog from the changelog module

### DIFF
--- a/obal/data/playbooks/changelog/changelog.yaml
+++ b/obal/data/playbooks/changelog/changelog.yaml
@@ -9,4 +9,4 @@
     - name: 'ensure changelog'
       changelog:
         spec: "{{ spec_file_path }}"
-        changelog: "{{ changelog | default('- rebuilt') }}"
+        entry: "{{ changelog | default('- rebuilt') }}"

--- a/obal/data/roles/update_spec_file/tasks/main.yml
+++ b/obal/data/roles/update_spec_file/tasks/main.yml
@@ -61,5 +61,5 @@
 - name: 'add changelog entry'
   changelog:
     spec: "{{ spec_file_path }}"
-    changelog: "{{ changelog }}"
+    entry: "{{ changelog }}"
   when: changelog is defined


### PR DESCRIPTION
Additionally changes the changelog module parameter from changelog
to entry to better reflect what the parameter being supplied is
and reduce the occurrances of the word changelog. The intent is for
changelog to represent the whole changelog and entry to represent
an item in the changelog.