### PR TITLE
Refactor update

### DIFF
--- a/obal/data/playbooks/update/metadata.obal.yaml
+++ b/obal/data/playbooks/update/metadata.obal.yaml
@@ -27,3 +27,5 @@ variables:
   commit:
     help: When true, creates a git branch and commits the update changes to it.
     action: store_true
+  template:
+    help: The template to use

--- a/obal/data/playbooks/update/update.yaml
+++ b/obal/data/playbooks/update/update.yaml
@@ -23,9 +23,37 @@
       when:
         - "'://' in item"
 
-    - name: 'Fetch sources'
+    - name: 'fetch sources'
       include_role:
         name: fetch_sources
+
+    - name: 'update spec file'
+      include_role:
+        name: update_spec_file
+
+    - name: 'update source files'
+      include_role:
+        name: setup_sources
+
+    - when:
+        - template is defined
+        - "'rubygem' in inventory_hostname"
+      block:
+        - name: Read changelog
+          changelog:
+            spec: "{{ spec_file_path }}"
+          register: changelog
+
+        - name: Run spec update template
+          shell: "gem2rpm -o {{ spec_file_path }} -t {{ template }} {{ inventory_dir }}/{{ package_base_dir }}/{{ inventory_hostname }}/*.gem"
+          args:
+            chdir: "{{ inventory_dir }}"
+
+        - name: Add back changelog
+          lineinfile:
+            path: "{{ spec_file_path }}"
+            insertafter: "%changelog"
+            line: "{{ changelog.changelog }}"
 
     - name: Determine new source file from spec
       shell: "spectool --list-files --all {{ spec_file_path }} | awk '{print $2}'"
@@ -50,6 +78,41 @@
       with_items: "{{ new_source_urls.stdout_lines | list }}"
       when:
         - "'://' not in item"
+
+    - name: Check for updates
+      command: "git status --porcelain {{ inventory_dir }}/{{ package_base_dir }}/{{ inventory_hostname }}"
+      register: git_status
+      args:
+        chdir: "{{ inventory_dir }}"
+      changed_when: false
+
+    - when: git_status.stdout
+      block:
+        - name: 'Bump release'
+          command: "rpmdev-bumpspec {{ spec_file_path | basename }} -c \"Update spec file\""
+          args:
+            chdir: "{{ spec_file_path | dirname }}"
+          changed_when: true
+          when: version is not defined
+
+        - name: 'Reset release in specfile'
+          replace:
+            path: "{{ spec_file_path }}"
+            regexp: '^(?P<prefix>{{ item }}\s+)[0-9.]+(?P<suffix>.*)$'
+            replace: '\g<prefix>1\g<suffix>'
+          with_items:
+            - 'Release:'
+            - '%global _release'
+            - '%global release'
+          when:
+            - version is defined
+            - release is not defined
+
+        - name: 'Add changelog entry'
+          changelog:
+            spec: "{{ spec_file_path }}"
+            entry: "Release {{ version }}"
+          when: version is defined
 
 - hosts:
     - packages

--- a/obal/data/roles/fetch_sources/tasks/main.yml
+++ b/obal/data/roles/fetch_sources/tasks/main.yml
@@ -1,5 +1,10 @@
 ---
-- block:
+- when:
+    - upstream is defined
+    - upstream.endswith('.git')
+    - upstream_files is defined
+    - version is not defined
+  block:
     - name: 'Extract upstream directory'
       set_fact:
         upstream_directory: "{{ upstream.split('/')[-1] }}"
@@ -17,18 +22,18 @@
         src: "{{ obal_tmp_dir }}/{{ upstream_directory }}/{{ item }}"
         dest: "{{ inventory_dir }}/{{ package_base_dir }}/{{ inventory_hostname }}/"
       with_items: "{{ upstream_files }}"
-  when:
-    - upstream is defined
-    - upstream.endswith('.git')
-    - upstream_files is defined
-    - version is not defined
   rescue:
     - name: 'Remove package directory'
       file:
         state: 'absent'
         path: "{{ inventory_dir }}/{{ package_base_dir }}/{{ inventory_hostname }}"
 
-- block:
+- when:
+    - upstream is defined
+    - upstream.endswith('src.rpm')
+    - upstream_files is defined
+    - version is not defined
+  block:
     - name: 'Make package download directory'
       file:
         state: 'directory'
@@ -56,43 +61,8 @@
         src: "{{ obal_tmp_dir }}/{{ inventory_hostname }}/{{ item }}"
         dest: "{{ inventory_dir }}/{{ package_base_dir }}/{{ inventory_hostname }}/"
       with_items: "{{ upstream_files }}"
-  when:
-    - upstream is defined
-    - upstream.endswith('src.rpm')
-    - upstream_files is defined
-    - version is not defined
   rescue:
     - name: 'Remove package directory'
       file:
         state: 'absent'
         path: "./{{ package_base_dir }}/{{ inventory_hostname }}"
-
-- block:
-    - include_role:
-        name: spec_file
-
-    - name: 'Set setup flag'
-      set_fact:
-        setup_sources_flags: '-f'
-
-    - name: 'Set release'
-      set_fact:
-        release: '1'
-      when:
-        - release is not defined
-        - version is defined
-
-    - name: 'Set default changelog'
-      set_fact:
-        changelog: '- Release {{ inventory_hostname }} {{ version }}{{ prerelease | default("") }}'
-      when:
-        - changelog is not defined
-        - version is defined
-
-    - name: 'update spec file'
-      include_role:
-        name: update_spec_file
-
-    - name: 'update source files'
-      include_role:
-        name: setup_sources

--- a/tests/fixtures/help/update.txt
+++ b/tests/fixtures/help/update.txt
@@ -1,6 +1,6 @@
 usage: obal update [-h] [-v] [-e EXTRA_VARS] [--changelog CHANGELOG]
                    [--commit] [--prerelease PRERELEASE] [--release RELEASE]
-                   [--version VERSION]
+                   [--template TEMPLATE] [--version VERSION]
                    target [target ...]
 
 Update a package to a newer version
@@ -35,6 +35,7 @@ optional arguments:
                         the prerelease macro will be removed
   --release RELEASE     Optionally set the release. When unspecified, the
                         release will be set to 1
+  --template TEMPLATE   The template to use
   --version VERSION     Optionally update to an explicit version. When
                         unspecified, the latest version from the upstream will
                         be used

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -393,7 +393,7 @@ def test_obal_update_upstream_hello():
 
     assert 'Version:        2.8' in specfilecontent
     assert 'Release:        1' in specfilecontent
-    assert '- Release hello 2.8' in specfilecontent
+    assert '- Release 2.8' in specfilecontent
     assert '%global prerelease' not in specfilecontent
 
 
@@ -410,7 +410,7 @@ def test_obal_update_upstream_hello_prerelease():
 
     assert 'Version:        2.8' in specfilecontent
     assert 'Release:        1' in specfilecontent
-    assert '- Release hello 2.8' in specfilecontent
+    assert '- Release 2.8' in specfilecontent
     assert '%global prereleasesource rc1' in specfilecontent
 
 
@@ -427,7 +427,7 @@ def test_obal_update_upstream_hello_keeprelease():
 
     assert 'Version:        2.8' in specfilecontent
     assert 'Release:        2' in specfilecontent
-    assert '- Release hello 2.8' in specfilecontent
+    assert '- Release 2.8' in specfilecontent
 
 
 @obal_cli_test(repotype='downstream')
@@ -471,7 +471,7 @@ def test_obal_update_downstream_with_version_hello():
     assert 'Version:        2.10' in specfilecontent
     assert 'Source0:        http://ftp.gnu.org/gnu' in specfilecontent
     assert 'Version:        2.9' not in specfilecontent
-    assert '- Release hello' in specfilecontent
+    assert '- Release 2.10' in specfilecontent
 
 
 @obal_cli_test(repotype='empty')


### PR DESCRIPTION
This shows where reading the changelog would be used. This change is a draft to start as it needs NPM support added and there may be some opportunities to do parts of this cleaner or with a module.

The general idea is that right now the update command only updates the version and adds a changelog entry but does no updates to the spec file dependencies. This, when updating versions, can miss new requires or updates to dependency versions. This adds running of spec updates for gem packages (NPM to come) based on the template that is either specified on the command line or (ideally) defined in the package_manifest. This also aims towards idempotency for the update command.