### PR TITLE
Change package_whitelist_check to package_tag_check

### DIFF
--- a/obal/data/module_utils/obal.py
+++ b/obal/data/module_utils/obal.py
@@ -58,12 +58,15 @@ def get_specfile_nevr(specfile, scl=None, dist=None, macros=None):
     return specfile_macro_lookup(specfile, '%{nevr}', scl=scl, dist=dist, macros=macros)
 
 
-def get_whitelist_status(build_command, tag, package):
+def package_exists(build_command, tag, package):
     """
-    Get whitelist status of a given package within a tag.
+    Check if package exists within a tag.
 
-    Return `True` if the package is whitelisted, `False` otherwise.
+    Return `True` if the package added to the tag, `False` otherwise.
     """
+    if not build_command:
+        build_command = 'koji'
+
     cmd = [
         build_command,
         'list-pkgs',

--- a/obal/data/modules/package_tag_check.py
+++ b/obal/data/modules/package_tag_check.py
@@ -8,13 +8,7 @@ except ImportError:
 import os
 
 from ansible.module_utils.basic import AnsibleModule  # pylint: disable=C0413
-from ansible.module_utils.obal import get_specfile_name, get_whitelist_status  # pylint:disable=import-error,no-name-in-module
-
-ANSIBLE_METADATA = {
-    'metadata_version': '1.2',
-    'status': ['preview'],
-    'supported_by': 'community'
-}
+from ansible.module_utils.obal import get_specfile_name, package_exists  # pylint:disable=import-error,no-name-in-module
 
 
 def run_module():
@@ -31,7 +25,7 @@ def run_module():
         changed=False,
         branches=[],
         autobuild_tags=[],
-        whitelist_status=dict(),
+        status=dict(),
     )
 
     releasers_config = module.params['releasers_conf']
@@ -56,13 +50,12 @@ def run_module():
     if not result['branches'] and not result['autobuild_tags']:
         module.fail_json(msg="No branches or autobuild_tags were found mapped to {}.".format(module.params['releasers']), **result)
 
-    # check whitelist status
     for tag in result['branches'] + result['autobuild_tags']:
-        status = get_whitelist_status(module.params['build_command'], tag, package_name)
-        result['whitelist_status'][tag] = status
+        status = package_exists(module.params['build_command'], tag, package_name)
+        result['status'][tag] = status
 
-    if not all(result['whitelist_status'].values()):
-        module.fail_json(msg="Package has not been whitelisted for given branches and autobuild_tags", **result)
+    if not all(result['status'].values()):
+        module.fail_json(msg="Package has not been added to given branches and autobuild_tags", **result)
 
     module.exit_json(**result)
 

--- a/obal/data/playbooks/nightly/metadata.obal.yaml
+++ b/obal/data/playbooks/nightly/metadata.obal.yaml
@@ -14,7 +14,7 @@ variables:
     parameter: --scratch
     action: store_true
     help: Set --scratch for scratch builds.
-  build_package_koji_whitelist_check:
+  build_package_koji_tag_check:
     action: store_false
-    parameter: --skip-koji-whitelist-check
-    help: ignore koji whitelist check and release the package anyway
+    parameter: --skip-koji-tag-check
+    help: Ignore koji tag check and release the package anyway

--- a/obal/data/playbooks/release/metadata.obal.yaml
+++ b/obal/data/playbooks/release/metadata.obal.yaml
@@ -4,7 +4,7 @@ help: |
 
   No action is performed if a release of the exact same version already exists.
 variables:
-  build_package_koji_whitelist_check:
+  build_package_koji_tag_check:
     action: store_false
-    parameter: --skip-koji-whitelist-check
-    help: ignore koji whitelist check and release the package anyway
+    parameter: --skip-koji-tag-check
+    help: Ignore Koji tag check and release the package anyway

--- a/obal/data/playbooks/scratch/metadata.obal.yaml
+++ b/obal/data/playbooks/scratch/metadata.obal.yaml
@@ -4,7 +4,7 @@ help: |
 
   A scratch build produces the same result as a normal release would, but it's not tagged in any repository. This allows verification of a change without actually committing it.
 variables:
-  build_package_koji_whitelist_check:
+  build_package_koji_tag_check:
     action: store_false
-    parameter: --skip-koji-whitelist-check
-    help: ignore koji whitelist check and scratch build the package anyway
+    parameter: --skip-koji-tag-check
+    help: Ignore Koji tag check and scratch build the package anyway

--- a/obal/data/roles/build_package/defaults/main.yaml
+++ b/obal/data/roles/build_package/defaults/main.yaml
@@ -9,5 +9,5 @@ build_package_wait: true
 build_package_download_logs: false
 build_package_download_rpms: false
 build_package_waitrepo: false
-build_package_koji_whitelist_check: false
+build_package_koji_tag_check: false
 build_package_tito_builder:

--- a/obal/data/roles/build_package/tasks/koji.yml
+++ b/obal/data/roles/build_package/tasks/koji.yml
@@ -1,11 +1,11 @@
 ---
-- name: "Confirm package is whitelisted"
-  package_whitelist_check:
+- name: "Confirm package is add to the tag"
+  package_tag_check:
     releasers_conf: "{{ inventory_dir }}/rel-eng/releasers.conf"
     spec_file_path: "{{ spec_file_path }}"
     releasers: "{{ releasers }}"
     build_command: "{{ build_package_koji_command }}"
-  when: build_package_koji_whitelist_check | bool
+  when: build_package_koji_tag_check | bool
 
 - name: 'Set tito_releasers for brew scratch'
   set_fact:

--- a/tests/fixtures/help/nightly.txt
+++ b/tests/fixtures/help/nightly.txt
@@ -1,4 +1,4 @@
-usage: obal nightly [-h] [-v] [-e EXTRA_VARS] [--skip-koji-whitelist-check]
+usage: obal nightly [-h] [-v] [-e EXTRA_VARS] [--skip-koji-tag-check]
                     [--scratch] [--githash NIGHTLY_GITHASH]
                     [--source NIGHTLY_SOURCEFILES]
                     target [target ...]
@@ -13,9 +13,8 @@ positional arguments:
 optional arguments:
   -h, --help            show this help message and exit
   -v, --verbose         verbose output
-  --skip-koji-whitelist-check
-                        ignore koji whitelist check and release the package
-                        anyway
+  --skip-koji-tag-check
+                        Ignore koji tag check and release the package anyway
   --scratch             Set --scratch for scratch builds.
   --githash NIGHTLY_GITHASH
                         Git commit hash to be included in the RPM's release.

--- a/tests/fixtures/help/release.txt
+++ b/tests/fixtures/help/release.txt
@@ -1,4 +1,4 @@
-usage: obal release [-h] [-v] [-e EXTRA_VARS] [--skip-koji-whitelist-check]
+usage: obal release [-h] [-v] [-e EXTRA_VARS] [--skip-koji-tag-check]
                     target [target ...]
 
 This action releases a package to Koji/Brew/Copr
@@ -11,9 +11,8 @@ positional arguments:
 optional arguments:
   -h, --help            show this help message and exit
   -v, --verbose         verbose output
-  --skip-koji-whitelist-check
-                        ignore koji whitelist check and release the package
-                        anyway
+  --skip-koji-tag-check
+                        Ignore Koji tag check and release the package anyway
 
 advanced arguments:
   -e EXTRA_VARS, --extra-vars EXTRA_VARS

--- a/tests/fixtures/help/scratch.txt
+++ b/tests/fixtures/help/scratch.txt
@@ -1,4 +1,4 @@
-usage: obal scratch [-h] [-v] [-e EXTRA_VARS] [--skip-koji-whitelist-check]
+usage: obal scratch [-h] [-v] [-e EXTRA_VARS] [--skip-koji-tag-check]
                     target [target ...]
 
 Create a scratch build of a package
@@ -11,9 +11,9 @@ positional arguments:
 optional arguments:
   -h, --help            show this help message and exit
   -v, --verbose         verbose output
-  --skip-koji-whitelist-check
-                        ignore koji whitelist check and scratch build the
-                        package anyway
+  --skip-koji-tag-check
+                        Ignore Koji tag check and scratch build the package
+                        anyway
 
 advanced arguments:
   -e EXTRA_VARS, --extra-vars EXTRA_VARS

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -174,16 +174,16 @@ def test_obal_release_upstream_hello():
 
 
 @obal_cli_test(repotype='upstream')
-def test_obal_release_upstream_hello_whitelist_check():
-    assert_obal_success(['release', 'hello', '-e', 'build_package_koji_whitelist_check=true'])
+def test_obal_release_upstream_hello_tag_check():
+    assert_obal_success(['release', 'hello', '-e', 'build_package_koji_tag_check=true'])
 
     expected_log_entry = "koji list-pkgs --tag obaltest-nightly-rhel7 --package hello --quiet"
     assert_in_mockbin_log(expected_log_entry)
 
 
 @obal_cli_test(repotype='upstream')
-def test_obal_release_upstream_hello_no_whitelist_check():
-    assert_obal_success(['release', 'hello', '-e', 'build_package_koji_whitelist_check=false'])
+def test_obal_release_upstream_hello_no_tag_check():
+    assert_obal_success(['release', 'hello', '-e', 'build_package_koji_tag_check=false'])
 
     unexpected_log_entry = "koji list-pkgs --tag obaltest-nightly-rhel7 --package hello --quiet"
     assert_not_in_mockbin_log(unexpected_log_entry)
@@ -231,16 +231,16 @@ def test_obal_nightly_upstream_hello():
 
 
 @obal_cli_test(repotype='downstream')
-def test_obal_release_downstream_hello_whitelist_check():
-    assert_obal_success(['release', 'hello', '-e', 'build_package_koji_whitelist_check=true'])
+def test_obal_release_downstream_hello_tag_check():
+    assert_obal_success(['release', 'hello', '-e', 'build_package_koji_tag_check=true'])
 
     expected_log_entry = "brew list-pkgs --tag obaltest-dist-git-rhel-7 --package hello --quiet"
     assert_in_mockbin_log(expected_log_entry)
 
 
 @obal_cli_test(repotype='downstream')
-def test_obal_release_downstream_hello_no_whitelist_check():
-    assert_obal_success(['release', 'hello', '-e', 'build_package_koji_whitelist_check=false'])
+def test_obal_release_downstream_hello_no_tag_check():
+    assert_obal_success(['release', 'hello', '-e', 'build_package_koji_tag_check=false'])
 
     unexpected_log_entry = "brew list-pkgs --tag obaltest-dist-git-rhel-7 --package hello --quiet"
     assert_not_in_mockbin_log(unexpected_log_entry)


### PR DESCRIPTION
We originally named this whitelist because that is the term tito
used to declaring the set of packages for a tag. This steps towards
using Koji directly by talking of checking if a package exists for
a tag.