### PR TITLE
Implement local source fetching

### DIFF
--- a/obal/data/modules/srpm.py
+++ b/obal/data/modules/srpm.py
@@ -123,7 +123,11 @@ def main():
                 module.fail_json(msg="Unknown source_system specified.",
                     source_system=source_system, valid_choices=VALID_SOURCE_SYSTEMS)
 
-        copy_sources(spec_file, package, sources_dir)
+        try:
+            copy_sources(spec_file, package, sources_dir)
+        except subprocess.CalledProcessError as error:
+            module.fail_json(msg='Failed to build srpm', output=error.output)
+
         shutil.copy(spec_file, base_dir)
 
         command = ['rpmbuild', '-bs']
@@ -153,8 +157,6 @@ def main():
         path = os.path.join(output, os.path.basename(result))
 
         module.exit_json(changed=True, path=path)
-    except subprocess.CalledProcessError as error:
-        module.fail_json(msg='Failed to build srpm', output=error.output)
     finally:
         shutil.rmtree(base_dir)
 

--- a/obal/data/playbooks/srpm/metadata.obal.yaml
+++ b/obal/data/playbooks/srpm/metadata.obal.yaml
@@ -2,7 +2,19 @@
 help: |
   Build a SRPM for packages
 
-  Building source RPMs can be useful when locally building packages.
+  Building source RPMs can be useful when locally building packages. For
+  example, when you've made local changes.
+
+    --source-system local-bundle-rake --source-location $HOME/foreman-installer
+
+  Not all projects need bundler so it's possible to run without.
+
+    --source-system local-bundle-rake --source-location $HOME/smart-proxy
+
+  It is also possible to retrieve the source from a Jenkins job.
+
+    --source-system jenkins --source-location https://ci.theforeman.org/job/foreman-installer-develop-source-release
+
 variables:
   build_srpm_dist:
     parameter: --dist
@@ -13,3 +25,7 @@ variables:
   build_srpm_output_dir:
     parameter: --dir
     help: Absolute path to output dir for SRPM. Defaults to <inventory_dir>/SRPMs
+  source_system:
+    help: The system to be used when passing source_location. Either jenkins, local-bundle-rake or local-rake.
+  source_location:
+    help: Source location. Format is dependent on the source system

--- a/obal/data/roles/build_srpm/meta/main.yaml
+++ b/obal/data/roles/build_srpm/meta/main.yaml
@@ -2,4 +2,3 @@
 dependencies:
   - role: setup_workspace
   - role: ensure_package
-  - role: setup_sources


### PR DESCRIPTION
This adds the ability to fetch sources by using:
(bundle exec) rake pkg:generate_source

This is implemented in the Foreman repositories and makes it easier to run local scratch builds.

It also fixes handling of remote sources and a TypeError.

The tests currently fail, but at least I've pushed my changes so I don't lose them.