### PR TITLE
Add koji build support

### DIFF
--- a/obal/data/module_utils/obal.py
+++ b/obal/data/module_utils/obal.py
@@ -78,6 +78,7 @@ def get_whitelist_status(build_command, tag, package):
         package,
         '--quiet'
     ]
+
     try:
         koji(cmd, build_command)
         return True

--- a/obal/data/modules/koji_build.py
+++ b/obal/data/modules/koji_build.py
@@ -1,0 +1,69 @@
+"""
+Release a package to koji
+"""
+
+import re
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.koji_wrapper import koji, KojiCommandError # pylint:disable=import-error,no-name-in-module
+from ansible.module_utils.obal import get_whitelist_status  # pylint:disable=import-error,no-name-in-module
+
+
+def main():
+    """
+    Build a package in koji
+    """
+    module = AnsibleModule(
+        argument_spec=dict(
+            srpm=dict(type='path', required=True),
+            scratch=dict(type='bool', required=False, default=False),
+            tag=dict(type='str', required=True),
+            nevr=dict(type='str', required=True),
+            package=dict(type='str', required=True),
+            tag_check=dict(type='bool', required=False, default=True),
+            koji_executable=dict(type='str', required=False)
+        )
+    )
+
+    tag = module.params['tag']
+    scratch = module.params['scratch']
+    srpm = module.params['srpm']
+    nevr = module.params['nevr']
+    package = module.params['package']
+    koji_executable = module.params['koji_executable']
+
+    if module.params['tag_check']:
+        if not get_whitelist_status(koji_executable, tag, package):
+            module.fail_json(msg="Package {} has not been added to tag {}".format(package, tag))
+
+    if not scratch:
+        try:
+            command = ['latest-build', '--quiet', tag, package]
+            koji_output = koji(command, koji_executable)
+            build = koji_output.split(' ')[0].strip()
+
+            if build == nevr:
+                module.exit_json(changed=False, build=build)
+        except KojiCommandError as error:
+            module.fail_json(changed=False, msg=error, command=command)
+
+    command = ['build', tag, srpm]
+
+    if scratch:
+        command.append('--scratch')
+
+    try:
+        output = koji(command, koji_executable)
+    except KojiCommandError as error:
+        module.fail_json(msg='Failed to koji build', command=error.cmd, output=error.output,
+                         tag=tag, scratch=scratch, srpm=srpm, code=error.returncode)
+
+    tasks = re.findall(r'^Created task:\s(\d+)', output, re.MULTILINE)
+    task_urls = re.findall(r'^Task info:\s(.+)', output, re.MULTILINE)
+    builds = re.findall(r'^Created builds:\s(\d+)', output, re.MULTILINE)
+
+    module.exit_json(changed=True, output=output, tasks=tasks, task_urls=task_urls, builds=builds)
+
+
+if __name__ == '__main__':
+    main()

--- a/obal/data/roles/build_package/defaults/main.yaml
+++ b/obal/data/roles/build_package/defaults/main.yaml
@@ -11,3 +11,4 @@ build_package_download_rpms: false
 build_package_waitrepo: false
 build_package_koji_whitelist_check: false
 build_package_tito_builder:
+build_package_use_koji_build: false

--- a/obal/data/roles/build_package/tasks/koji.yml
+++ b/obal/data/roles/build_package/tasks/koji.yml
@@ -1,40 +1,11 @@
 ---
-- name: "Confirm package is whitelisted"
-  package_whitelist_check:
-    releasers_conf: "{{ inventory_dir }}/rel-eng/releasers.conf"
-    spec_file_path: "{{ spec_file_path }}"
-    releasers: "{{ releasers }}"
-    build_command: "{{ build_package_koji_command }}"
-  when: build_package_koji_whitelist_check | bool
+- name: 'Use tito to build package'
+  include_tasks: tito_release.yml
+  when: not build_package_use_koji_build
 
-- name: 'Set tito_releasers for brew scratch'
-  set_fact:
-    build_package_tito_releasers: "{{ releasers | map('replace', 'dist-git', 'scratch') | list }}"
-  when: build_package_koji_command == 'brew' and build_package_scratch
-
-- name: 'Set tito_releasers'
-  set_fact:
-    build_package_tito_releasers: "{{ releasers }}"
-  when: build_package_koji_command != 'brew' or not build_package_scratch
-
-- name: 'Release to {{ build_package_koji_command }}'
-  tito_release:
-    directory: "{{ inventory_dir }}/{{ package_base_dir }}/{{ inventory_hostname }}"
-    arguments: "{{ build_package_tito_args }}"
-    scratch: "{{ build_package_scratch and build_package_koji_command != 'brew'}}"
-    test: "{{ build_package_test }}"
-    releasers: "{{ build_package_tito_releasers }}"
-    releaser_arguments: "{{ build_package_tito_releaser_args }}"
-  register: build_package_tito_release
-
-- name: 'Created tasks'
-  debug:
-    var: build_package_tito_release.task_urls
-
-- name: 'Wait for tasks to finish'
-  include_tasks: wait.yml
-  when: build_package_wait|bool
-
-- name: 'Download task results'
-  include_tasks: download_rpms.yml
-  when: build_package_download_rpms|bool
+- when: build_package_use_koji_build
+  block:
+    - include_tasks: koji_build.yml
+      loop: "{{ koji_tags }}"
+      loop_control:
+        loop_var: tag

--- a/obal/data/roles/build_package/tasks/koji_build.yml
+++ b/obal/data/roles/build_package/tasks/koji_build.yml
@@ -1,0 +1,50 @@
+---
+- name: "Package name"
+  rpm_nevr:
+    spec_file: "{{ spec_file_path }}"
+    scl: "{{ tag.scl | default(omit) }}"
+    dist: "{{ tag.dist | default(omit) }}"
+    macros: "{{ tag.macros | default(omit) }}"
+  register: package_nevr
+
+- name: create temporary build directory
+  tempfile:
+    state: directory
+    suffix: srpms
+  register: srpm_directory
+  when: srpm_directory is not defined
+
+- name: 'Build SRPM'
+  srpm:
+    package: "{{ inventory_dir }}/{{ package_base_dir }}/{{ inventory_hostname }}"
+    output: "{{ srpm_directory.path if 'path' in srpm_directory else srpm_directory }}"
+    scl: "{{ scl | default(omit) }}"
+    source_location: "{{ source_location | default(omit) }}"
+    source_system: "{{ source_system | default(omit) }}"
+  register: srpm_build
+
+- name: "Build package in Koji"
+  koji_build:
+    scratch: "{{ build_package_scratch }}"
+    tag: "{{ tag.name }}"
+    srpm: "{{ srpm_build.path }}"
+    package: "{{ package_nevr.name }}"
+    nevr: "{{ package_nevr.nevr }}"
+    koji_executable: "{{ build_package_koji_command }}"
+    tag_check: "{{ build_package_koji_whitelist_check }}"
+  register: koji_build_tasks
+
+- name: 'Created tasks'
+  debug:
+    var: koji_build_tasks.task_urls
+  when: koji_build_tasks.changed
+
+- name: 'Wait for tasks to finish'
+  include_tasks: wait.yml
+  when: build_package_wait|bool and koji_build_tasks.changed
+  vars:
+    koji_tasks: "{{ koji_build_tasks.tasks }}"
+
+- name: 'Download task results'
+  include_tasks: download_rpms.yml
+  when: build_package_download_rpms|bool

--- a/obal/data/roles/build_package/tasks/tito_release.yml
+++ b/obal/data/roles/build_package/tasks/tito_release.yml
@@ -1,0 +1,42 @@
+---
+- name: "Confirm package is whitelisted"
+  package_whitelist_check:
+    releasers_conf: "{{ inventory_dir }}/rel-eng/releasers.conf"
+    spec_file_path: "{{ spec_file_path }}"
+    releasers: "{{ releasers }}"
+    build_command: "{{ build_package_koji_command }}"
+  when: build_package_koji_whitelist_check | bool
+
+- name: 'Set tito_releasers for brew scratch'
+  set_fact:
+    build_package_tito_releasers: "{{ releasers | map('replace', 'dist-git', 'scratch') | list }}"
+  when: build_package_koji_command == 'brew' and build_package_scratch
+
+- name: 'Set tito_releasers'
+  set_fact:
+    build_package_tito_releasers: "{{ releasers }}"
+  when: build_package_koji_command != 'brew' or not build_package_scratch
+
+- name: 'Release to {{ build_package_koji_command }}'
+  tito_release:
+    directory: "{{ inventory_dir }}/{{ package_base_dir }}/{{ inventory_hostname }}"
+    arguments: "{{ build_package_tito_args }}"
+    scratch: "{{ build_package_scratch and build_package_koji_command != 'brew'}}"
+    test: "{{ build_package_test }}"
+    releasers: "{{ build_package_tito_releasers }}"
+    releaser_arguments: "{{ build_package_tito_releaser_args }}"
+  register: build_package_tito_release
+
+- name: 'Created tasks'
+  debug:
+    var: build_package_tito_release.task_urls
+
+- name: 'Wait for tasks to finish'
+  include_tasks: wait.yml
+  when: build_package_wait|bool
+  vars:
+    koji_tasks: "{{ build_package_tito_release.tasks }}"
+
+- name: 'Download task results'
+  include_tasks: download_rpms.yml
+  when: build_package_download_rpms|bool

--- a/obal/data/roles/build_package/tasks/wait.yml
+++ b/obal/data/roles/build_package/tasks/wait.yml
@@ -1,7 +1,7 @@
 ---
 - block:
     - name: "Watch {{ build_package_koji_command }} task(s)"
-      command: "{{ build_package_koji_command }} watch-task {{ build_package_tito_release.tasks | join(' ') }}"
+      command: "{{ build_package_koji_command }} watch-task {{ koji_tasks | join(' ') }}"
       ignore_errors: true
       register: build_package_koji_status
       changed_when: false
@@ -17,7 +17,7 @@
 
     - name: "Get {{ build_package_koji_command }} build detals"
       command: "{{ build_package_koji_command }} taskinfo -v {{ item }}"
-      with_items: "{{ build_package_tito_release.tasks }}"
+      with_items: "{{ koji_tasks }}"
       changed_when: false
       register: build_package_koji_task_info
 

--- a/tests/fixtures/mockbin/mockbin
+++ b/tests/fixtures/mockbin/mockbin
@@ -113,10 +113,22 @@ elif prog in ['koji', 'brew']:
     parser_latest_build.add_argument('pkg')
     parser_latest_build.add_argument('--quiet', action='store_true')
 
+    parser_build = subparsers.add_parser('build')
+    parser_build.add_argument('tag')
+    parser_build.add_argument('pkg')
+    parser_build.add_argument('--scratch', action='store_true')
+
     parser_taskinfo.add_argument('-v', action='store_const', dest='output', const=_FAKE_TASKINFO)
     args = parser.parse_args()
+
     if 'output' in args and args.output:
         print(args.output)
+
+    if 'build' in sys.argv:
+        print('Created task: 1234')
+
+    if 'package-with-existing-build' in sys.argv:
+        print('package-with-existing-build-1.0-1.el7')
 
 elif prog in ['copr-cli']:
     print({})

--- a/tests/fixtures/testrepo/upstream/package_manifest.yaml
+++ b/tests/fixtures/testrepo/upstream/package_manifest.yaml
@@ -15,6 +15,7 @@ packages:
       nightly_package_tito_releaser_args:
         - "jenkins_job=hello-master-release"
     foo: {}
+    package-with-existing-build: {}
 
 repoclosures:
   vars:

--- a/tests/fixtures/testrepo/upstream/packages/package-with-existing-build/package-with-existing-build-source
+++ b/tests/fixtures/testrepo/upstream/packages/package-with-existing-build/package-with-existing-build-source
@@ -1,0 +1,3 @@
+Bar!
+Baz!
+No Foo!

--- a/tests/fixtures/testrepo/upstream/packages/package-with-existing-build/package-with-existing-build.spec
+++ b/tests/fixtures/testrepo/upstream/packages/package-with-existing-build/package-with-existing-build.spec
@@ -1,0 +1,27 @@
+Name:           package-with-existing-build
+Version:        1.0
+Release:        1%{?dist}
+Summary:        I love bars
+
+License:        GPLv3+
+Source0:        package-with-existing-build-source
+
+Requires:       wget
+
+%description
+A fake RPM for package-with-existing-builds and bars.
+
+%prep
+%autosetup
+
+%build
+
+%install
+cp . %{buildroot}/
+
+%files
+package-with-existing-build-source
+
+%changelog
+* Tue Dec 11 2018 Foo Bar Man <package-with-existing-build@bar.package-with-existing-build> 1.0-1
+- Initial version of the package

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,7 @@ deps =
 commands =
     check-manifest --ignore tox.ini,.ansible-lint,tests*,tests/**,docs*,docs/**,*/**/*.pyc,*/**/__pycache__,.yamllint
     python setup.py check -m -s
-    pytest -n 4 --flakes --pylint --pylint-rcfile={toxinidir}/.pylintrc --cov=obal --cov-report term --cov-report xml --boxed {posargs}
+    pytest -v -n 4 --flakes --pylint --pylint-rcfile={toxinidir}/.pylintrc --cov=obal --cov-report term --cov-report xml --boxed {posargs}
     - coveralls
 
 [flake8]


### PR DESCRIPTION
Requires -- ~~https://github.com/theforeman/obal/pull/302~~

This is an evolution of https://github.com/theforeman/obal/pull/230 where this PR adds the functionality and the ability to enable this functionality directly through a flag. All existing projects using this will continue to use tito as before. But projects can opt in to testing/using builds directly through koji by setting:

```
build_package_use_koji_build: true
```