### PR TITLE
Use splitlines instead of split for getting evr from changelog

### DIFF
--- a/obal/data/module_utils/obal.py
+++ b/obal/data/module_utils/obal.py
@@ -40,7 +40,7 @@ def get_changelog_evr(specfile):
         specfile
     ]
     evr = subprocess.check_output(cmd, universal_newlines=True)
-    return evr.split('\n', maxsplit=1)[0].split(" ")[-1]
+    return evr.splitlines()[0].split(" ")[-1]
 
 
 def get_specfile_evr(specfile):

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -1,6 +1,10 @@
-from obal.data.module_utils.obal import get_specfile_sources
+from obal.data.module_utils.obal import get_specfile_sources, get_changelog_evr
 
 
 def test_get_specfile_sources():
     sources = get_specfile_sources('tests/fixtures/testrepo/upstream/packages/hello/hello.spec')
     assert sources == ['http://ftp.gnu.org/gnu/hello/hello-2.10.tar.gz']
+
+def test_get_changelog_evr():
+    evr = get_changelog_evr('tests/fixtures/testrepo/upstream/packages/hello/hello.spec')
+    assert evr == '2.10-2'


### PR DESCRIPTION
This is breaking CI tasks presently:

https://ci.theforeman.org/blue/organizations/jenkins/foreman-packaging-rpm-pr-test/detail/foreman-packaging-rpm-pr-test/7834/pipeline/