### PR TITLE
Add ability to check if package exists in Koji

### DIFF
--- a/obal/data/modules/check_koji_build.py
+++ b/obal/data/modules/check_koji_build.py
@@ -11,7 +11,7 @@ def main():
     """
     module = AnsibleModule(
         argument_spec=dict(
-            tag=dict(type='str', required=True),
+            tag=dict(type='str', required=False),
             nevr=dict(type='str', required=True),
             package=dict(type='str', required=True),
             koji_executable=dict(type='str', required=False)
@@ -23,13 +23,20 @@ def main():
     package = module.params['package']
     koji_executable = module.params['koji_executable']
 
-    command = ['latest-build', '--quiet', tag, package]
-
     try:
-        build = koji(command, koji_executable)
-        build = build.split(' ')[0]
+        if tag:
+            command = ['latest-build', '--quiet', tag, package]
+            build = koji(command, koji_executable)
+            build = build.split(' ')[0]
 
-        module.exit_json(changed=False, tagged_version=build, exists=(nevr == build))
+            module.exit_json(changed=False, tagged_version=build, exists=(nevr == build))
+        else:
+            command = ['buildinfo', nevr]
+            output = koji(command, koji_executable)
+            exists = 'No such build' not in output
+
+            module.exit_json(changed=False, exists=exists)
+
     except KojiCommandError as error:
         module.fail_json(changed=False, msg=error.message, command=error.command)
 


### PR DESCRIPTION
Previously, the check_koji_build only allowed checking if a package
build existed within a tag, this allows checking if the build exists
in Koji anywhere.