### PR TITLE
also explicitly use -c annex.largefiles=nothing when doing obal add

### DIFF
--- a/obal/data/playbooks/add/add.yaml
+++ b/obal/data/playbooks/add/add.yaml
@@ -32,7 +32,7 @@
             chdir: "{{ inventory_dir }}"
 
         - name: 'Git add new package'
-          command: "git add ./{{ package_base_dir }}/{{ inventory_hostname }}/*"
+          command: "git -c annex.largefiles=nothing add ./{{ package_base_dir }}/{{ inventory_hostname }}/*"
           args:
             chdir: "{{ inventory_dir }}"
 
@@ -49,7 +49,7 @@
             chdir: "{{ inventory_dir }}"
 
         - name: 'Git add new package'
-          command: "git add ./{{ package_base_dir }}/{{ inventory_hostname }}/*"
+          command: "git -c annex.largefiles=nothing add ./{{ package_base_dir }}/{{ inventory_hostname }}/*"
           when: git_status.stdout | length > 0
           args:
             chdir: "{{ inventory_dir }}"


### PR DESCRIPTION
this ensures files that are not listed for being annexed are not (git
annex defaults to annex large files)