### PR TITLE
Also run build_package if whitelist check is skipped

### DIFF
--- a/obal/data/playbooks/release/release.yaml
+++ b/obal/data/playbooks/release/release.yaml
@@ -7,4 +7,4 @@
     - role: diff_package
       when: not build_package_use_koji_build
     - role: build_package
-      when: (build_package_use_koji_build or diff_package_changed|bool)
+      when: (build_package_use_koji_build or diff_package_changed is not defined or diff_package_changed|bool)


### PR DESCRIPTION
diff_package_changed is not defined when skipping the whitelist
check so we still need to run build_package in that case.