### PR TITLE
Only run the release workflow on Foreman

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ jobs:
   release:
 
     runs-on: ubuntu-latest
+    if: github.repository_owner == "theforeman"
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Otherwise forks may attempt to release. This typically fails because they lack the secret, but it's better not to try at all.