### PR TITLE
Adding the git_branching option

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM quay.io/centos/centos:stream8
 
 RUN echo "tsflags=nodocs" >> /etc/yum.conf && \
-    yum -y install git glibc-langpack-en epel-release python3-pip && \
-    yum clean all
+    dnf -y install git glibc-langpack-en epel-release python3-pip dnf-utils && \
+    dnf clean all
 
 ENV LANG=en_US.UTF-8 \
     LANGUAGE=en_US.UTF-8 \

--- a/obal/data/playbooks/update/metadata.obal.yaml
+++ b/obal/data/playbooks/update/metadata.obal.yaml
@@ -8,9 +8,13 @@ help: |
 
     obal update mypackage --version 3.4.5
 
-  To update a package to a new version and create a git branch for the change from the command line:
+  To update a package to a new version and create a commit for the change from the command line:
 
     obal update mypackage --version 3.4.5 --commit
+
+  To update a package to a new version and create a git branch for the change from the command line:
+
+    obal update mypackage --version 3.4.5 --branch
 
   Updating a package that is taken from an upstream repository assumes that the package_manifest already defines the upstream location. Thus, the command line to update to a newer version that is available upstream automatically is:
 
@@ -25,5 +29,8 @@ variables:
   changelog:
     help: Optionally set the changelog. When unspecified, an entry will be generated
   commit:
+    help: When true, commits the update changes to it into the current branch
+    action: store_true
+  branch:
     help: When true, creates a git branch and commits the update changes to it.
     action: store_true

--- a/obal/data/playbooks/update/update.yaml
+++ b/obal/data/playbooks/update/update.yaml
@@ -51,9 +51,25 @@
       when:
         - "'://' not in item"
 
+    - name: 'Get updated version from spec'
+      command: "rpmspec --query --queryformat=%{version} --srpm {{ spec_file_path }}"
+      args:
+        chdir: "{{ inventory_dir }}"
+      changed_when: false
+      register: updated_version
+      when: commit is defined and commit
+
+    - name: 'Create git commit'
+      command: "git commit -a -m 'Update {{ inventory_hostname }} to {{ updated_version.stdout }}'"
+      args:
+        chdir: "{{ inventory_dir }}"
+      run_once: true
+      changed_when: true
+      when: commit is defined and commit
+
 - hosts:
     - packages
   gather_facts: false
   roles:
-    - when: commit is defined and commit
+    - when: branch is defined and branch
       role: git_branch_and_commit

--- a/tests/fixtures/help/update.txt
+++ b/tests/fixtures/help/update.txt
@@ -1,5 +1,6 @@
 usage: obal update [-h] [-v] [-e EXTRA_VARS] [--changelog CHANGELOG]
-                   [--commit] [--prerelease PRERELEASE] [--release RELEASE]
+                   [--branch] [--commit]
+                   [--prerelease PRERELEASE] [--release RELEASE]
                    [--version VERSION]
                    target [target ...]
 
@@ -15,6 +16,10 @@ To update a package to a new version and create a git branch for the change from
 
   obal update mypackage --version 3.4.5 --commit
 
+To update a package to a new version and create a git branch for the change from the command line:
+
+  obal update mypackage --version 3.4.5 --branch
+
 Updating a package that is taken from an upstream repository assumes that the package_manifest already defines the upstream location. Thus, the command line to update to a newer version that is available upstream automatically is:
 
   obal update mypackage
@@ -22,9 +27,10 @@ Updating a package that is taken from an upstream repository assumes that the pa
 positional arguments:
   target                the target to execute the action against
 
-optional arguments:
+options:
   -h, --help            show this help message and exit
   -v, --verbose         verbose output
+  --branch              When true, creates a git branch and commits the update changes to it.
   --changelog CHANGELOG
                         Optionally set the changelog. When unspecified, an
                         entry will be generated


### PR DESCRIPTION
This will be used for pulpcore branching, the --commit make it hard to push/sync during branching, when we have at least 25+ package updates.

For this I'm adding a `--branching` to keep all commits in the same branch