### PR TITLE
Disable pylint R1735(use-dict-literal)

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,6 +1,6 @@
 [MASTER]
 ignore=docs,tests
 # Disable useless-object-inheritance because we still support py2
-disable=R0205,C0209,W1514
+disable=R0205,C0209,W1514,R1735
 min-similarity-lines=10
 max-line-length=120


### PR DESCRIPTION
As this rule would change our signature to AnsibleModule, I felt it was better to disable it for now rather than re-factor those.