### PR TITLE
reset locale by `setlocale(…, "")` as `resetlocale(…)` is deprecated

### DIFF
--- a/obal/data/modules/changelog.py
+++ b/obal/data/modules/changelog.py
@@ -28,7 +28,7 @@ def en_locale():
         try:
             yield
         finally:
-            locale.resetlocale(locale.LC_TIME)
+            locale.setlocale(locale.LC_TIME, "")
 
 
 def main():


### PR DESCRIPTION
deprecated in Python 3.11, removed in 3.13.

according to Python docs setting it to `""` should work with Python 2 and Python 3 just fine