### PR TITLE
use `develop` as the default branch in tests

### DIFF
--- a/obal/data/roles/setup_sources/tasks/git.yml
+++ b/obal/data/roles/setup_sources/tasks/git.yml
@@ -7,7 +7,7 @@
   git:
     repo: "{{ setup_sources_git }}"
     dest: "{{ setup_sources_git_checkout_dir }}"
-    version: "{{ git_branch | default('master') }}"
+    version: "{{ git_branch | default(omit) }}"
     force: true
     depth: 1
 

--- a/tests/fixtures/testrepo/downstream/package_manifest.yaml
+++ b/tests/fixtures/testrepo/downstream/package_manifest.yaml
@@ -16,11 +16,11 @@ packages:
   hosts:
     hello:
       upstream: "file://{{ inventory_dir }}/../upstream/.git"
-      branch: "master"
+      branch: "develop"
       upstream_files:
         - "packages/hello/"
     hello1:
       upstream: "file://{{ inventory_dir }}/../upstream/.git"
-      branch: "master"
+      branch: "develop"
       upstream_files:
         - "packages/hello/"

--- a/tests/fixtures/testrepo/empty/package_manifest.yaml
+++ b/tests/fixtures/testrepo/empty/package_manifest.yaml
@@ -9,6 +9,6 @@ packages:
   hosts:
     hello:
       upstream: "file://{{ inventory_dir }}/../upstream/.git"
-      branch: "master"
+      branch: "develop"
       upstream_files:
         - "packages/hello/"

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -20,7 +20,7 @@ DEFAULT_ARGS = ['-e', 'srpm_directory="/tmp/SRPMs"']
 
 
 def git_init(path):
-    subprocess.check_call(['git', 'init'], cwd=path)
+    subprocess.check_call(['git', 'init', '--initial-branch', 'develop'], cwd=path)
     subprocess.check_call(['git', 'config', 'user.email', 'test@example.test'])
     subprocess.check_call(['git', 'config', 'user.name', 'Test CI'])
     subprocess.check_call(['git', 'annex', 'init'], cwd=path)


### PR DESCRIPTION
`git init` defaults to the value of `init.defaultBranch` to create new repositories, but that can vary between installations and users. excplicitly call it with `--initial-branch` to avoid that.

also update the default branch in the code to `develop` which is the default across Foreman projects