### PR TITLE
try to import quote from shlex first, not pipes

### DIFF
--- a/tests/fixtures/mockbin/mockbin
+++ b/tests/fixtures/mockbin/mockbin
@@ -6,9 +6,9 @@ import os
 import sys
 import argparse
 try:
-    from pipes import quote
-except ImportError:
     from shlex import quote
+except ImportError:
+    from pipes import quote
 
 
 _FAKE_TASKINFO = """Task: 1234


### PR DESCRIPTION
Python 3.3+ has it as `shelex.quote` while Python 2 has it as `pipes.quote`. As the `pipes` module is deprecated since Python 3.11, this raises a deprecation warning:

    DeprecationWarning: 'pipes' is deprecated and slated for removal in Python 3.13
      from pipes import quote

We can easily avoid that by first trying `shlex.quote` and falling back to `pipes.quote` only for Python 2 where `shlex.quote` doesn't exist.