### PR TITLE
Attempt to fix broken tests

### DIFF
--- a/obal/data/roles/setup_sources/tasks/specfile.yml
+++ b/obal/data/roles/setup_sources/tasks/specfile.yml
@@ -1,4 +1,7 @@
 ---
+- include_role:
+    name: spec_file
+
 - name: 'Extract Sources from spec'
   shell: "spectool --list-files --all {{ spec_file_path }} | awk '{print $2}'"
   register: setup_sources_sources


### PR DESCRIPTION
There is odd behaviour and failure for tests with Python 3.10+:

```
PLAY [Release packages] ********************************************************

TASK [setup_workspace : Define tmp directory] **********************************
ok: [package-with-existing-build]

TASK [setup_workspace : Ensure .tmp directory] *********************************
ok: [package-with-existing-build]

TASK [git_annex_setup : Call git annex init] ***********************************
ok: [package-with-existing-build]

TASK [setup_sources : Set package_dir] *****************************************
ok: [package-with-existing-build]

TASK [setup_sources : Setup sources from specfile] *****************************
included: /home/ehelms/workspace/upstream/packaging/obal/.tox/py311/lib/python3.11/site-packages/obal/data/roles/setup_sources/tasks/specfile.yml for package-with-existing-build

TASK [setup_sources : Extract Sources from spec] *******************************
fatal: [package-with-existing-build]: FAILED! => 
  msg: |-
    The task includes an option with an undefined variable. The error was: 'spec_file_path' is undefined. 'spec_file_path' is undefined
  
    The error appears to be in '/home/ehelms/workspace/upstream/packaging/obal/.tox/py311/lib/python3.11/site-packages/obal/data/roles/setup_sources/tasks/specfile.yml': line 2, column 3, but may
    be elsewhere in the file depending on the exact syntax problem.
  
    The offending line appears to be:
  
    ---
    - name: 'Extract Sources from spec'
      ^ here
```

Where the `spec_file` role should be getting called as it's listed as a dependency of the `setup_sources` role. I am testing out a hard coded role import to see if it fixes things.