### PR TITLE
allow spec_file to be loaded multiple times

### DIFF
--- a/obal/data/roles/spec_file/meta/main.yml
+++ b/obal/data/roles/spec_file/meta/main.yml
@@ -1,3 +1,4 @@
 ---
 dependencies:
   - role: ensure_package
+allow_duplicates: true


### PR DESCRIPTION
this worked without until ansible-core 2.15 "fixed" role duplication checks in https://github.com/ansible/ansible/pull/78661