### PR TITLE
Fix SCL leaking into Copr SRPM build

### DIFF
--- a/obal/data/roles/build_srpm/tasks/main.yaml
+++ b/obal/data/roles/build_srpm/tasks/main.yaml
@@ -3,7 +3,7 @@
   srpm:
     package: "{{ inventory_dir }}/{{ package_base_dir }}/{{ inventory_hostname }}"
     output: "{{ build_srpm_output_dir }}"
-    scl: "{{ scl | default(omit) }}"
+    scl: "{{ build_srpm_scl | default(omit) }}"
     source_location: "{{ source_location | default(omit) }}"
     source_system: "{{ source_system | default(omit) }}"
   register: srpm_build


### PR DESCRIPTION
The change to using the srpm_build role caused the scl field to become False which was interpreted as a string creating incorrect SRPM names. For example, False-nodejs-sass.