### PR TITLE
Allow running repoclosure based on a URL and dist

### DIFF
--- a/obal/data/playbooks/repoclosure/metadata.obal.yaml
+++ b/obal/data/playbooks/repoclosure/metadata.obal.yaml
@@ -3,3 +3,11 @@ help: |
   Run repoclosure for a repository
 
   Repoclosure ensures that all dependencies are met and all packages are installable.
+variables:
+  repoclosure_check_repos:
+    store: append
+    parameter: --check
+    help: Link to a repository to target for repoclosure
+  repoclosure_target_dist:
+    parameter: --dist
+    help: Target dist to test against (e.g. el8)

--- a/obal/data/roles/repoclosure/defaults/main.yml
+++ b/obal/data/roles/repoclosure/defaults/main.yml
@@ -3,3 +3,4 @@ repoclosure_additional_repos: []
 repoclosure_config: repoclosure/yum.conf
 repoclosure_target_repos: {}
 repoclosure_lookaside_repos: {}
+repoclosure_check_repos: []

--- a/obal/data/roles/repoclosure/tasks/downloaded_rpms_repoclosure.yml
+++ b/obal/data/roles/repoclosure/tasks/downloaded_rpms_repoclosure.yml
@@ -1,0 +1,23 @@
+---
+- name: Find all downloaded repositories
+  find:
+    paths: "{{ inventory_dir }}/downloaded_rpms"
+    recurse: false
+    file_type: directory
+  register: downloaded_rpms_folders
+
+- name: Map repositories to dists
+  set_fact:
+    downloaded_rpms_dists: "{{ downloaded_rpms_folders.files | map(attribute='path') | map('basename') | list }}"
+
+- name: Include repoclosure
+  ansible.builtin.include_tasks:
+    file: repoclosure.yml
+  vars:
+    download_rpm_repos: "{{ dict([['name', 'downloaded_rpms'], ['url', inventory_dir + '/downloaded_rpms/' + dist]]) }}"
+    check_repos: "{{ repoclosure_target_repos[dist] | default([]) + ['downloaded_rpms'] }}"
+    additional_repos: "{{ repoclosure_additional_repos + [download_rpm_repos] }}"
+    lookaside_repos: "{{ repoclosure_lookaside_repos[dist] }}"
+  loop: "{{ downloaded_rpms_dists }}"
+  loop_control:
+    loop_var: dist

--- a/obal/data/roles/repoclosure/tasks/main.yml
+++ b/obal/data/roles/repoclosure/tasks/main.yml
@@ -1,33 +1,34 @@
 ---
-- name: Find all downloaded repositories
-  find:
-    paths: "{{ inventory_dir }}/downloaded_rpms"
-    recurse: false
-    file_type: directory
-  register: downloaded_rpms_folders
-
-- name: Map repositories to dists
-  set_fact:
-    downloaded_rpms_dists: "{{ downloaded_rpms_folders.files | map(attribute='path') | map('basename') | list }}"
-
 - name: Run repoclosure for all dists
-  include_tasks: repoclosure.yml
-  vars:
-    repoclosure_use_downloaded_rpms: true
-  loop: "{{ downloaded_rpms_dists }}"
-  loop_control:
-    loop_var: dist
+  include_tasks: downloaded_rpms_repoclosure.yml
   when:
-    - downloaded_rpms_dists
     - repoclosure_target_dist is not defined
+    - not repoclosure_check_repos
 
 - name: Run repoclosure for main repo
   include_tasks: repoclosure.yml
-  vars:
-    repoclosure_use_downloaded_rpms: false
   loop:
     - "{{ repoclosure_target_dist }}"
   loop_control:
     loop_var: dist
+  vars:
+    check_repos: "{{ repoclosure_target_repos[dist] }}"
+    lookaside_repos: "{{ repoclosure_lookaside_repos[dist] }}"
+    additional_repos: []
   when:
     - repoclosure_target_dist is defined
+    - not repoclosure_check_repos
+
+- name: Run repoclosure for a target repo
+  include_tasks: repoclosure.yml
+  loop:
+    - "{{ repoclosure_check_repos }}"
+  loop_control:
+    loop_var: repo_url
+    index_var: index
+  vars:
+    check_repos: "{{ 'repo' + index|string }}"
+    lookaside_repos: "{{ repoclosure_lookaside_repos[repoclosure_target_dist] }}"
+    additional_repos: "{{ [{'name': 'repo' + index|string, 'url': repo_url}] }}"
+  when:
+    - repoclosure_check_repos

--- a/obal/data/roles/repoclosure/tasks/repoclosure.yml
+++ b/obal/data/roles/repoclosure/tasks/repoclosure.yml
@@ -1,29 +1,4 @@
 - block:
-    - name: Generate downloaded_rpms dictionary for additional repositories
-      set_fact:
-        download_rpm_repos: "{{ dict([['name', 'downloaded_rpms'], ['url', inventory_dir + '/downloaded_rpms/' + dist]]) }}"
-      when: downloaded_rpms_dists
-
-    - name: Generate list of repositories
-      set_fact:
-        repoclosure_target_repos_all: "{{ repoclosure_target_repos[dist] | default([]) + ['downloaded_rpms'] }}"
-      when: downloaded_rpms_dists
-
-    - name: Generate list of repositories
-      set_fact:
-        repoclosure_target_repos_all: "{{ repoclosure_target_repos[dist] }}"
-      when: not downloaded_rpms_dists
-
-    - name: Set additional_repos
-      set_fact:
-        additional_repos: "{{ repoclosure_additional_repos + [download_rpm_repos] }}"
-      when: download_rpm_repos is defined
-
-    - name: Set additional_repos
-      set_fact:
-        additional_repos: "{{ repoclosure_additional_repos }}"
-      when: download_rpm_repos is not defined
-
     - name: Set config filename for repoclosure
       set_fact:
         config_filename: "{{ repoclosure_config | basename }}"
@@ -47,12 +22,12 @@
         regexp: "^cachedir.*"
         replace: "cachedir={{ temp_directory.path }}"
 
-    - name: 'Run repoclosure for {{ dist }}'
+    - name: 'Run repoclosure'
       repoclosure:
         config: "{{ temp_directory.path }}/{{ config_filename }}"
-        check: "{{ repoclosure_target_repos_all }}"
-        additional_repos: "{{ additional_repos }}"
-        lookaside: "{{ repoclosure_lookaside_repos[dist] }}"
+        check: "{{ check_repos | default([]) }}"
+        additional_repos: "{{ additional_repos | default([]) }}"
+        lookaside: "{{ lookaside_repos | default([]) }}"
       register: output
 
     - debug:

--- a/tests/fixtures/help/repoclosure.txt
+++ b/tests/fixtures/help/repoclosure.txt
@@ -1,4 +1,7 @@
-usage: obal repoclosure [-h] [-v] [-e EXTRA_VARS] target [target ...]
+usage: obal repoclosure [-h] [-v] [-e EXTRA_VARS]
+                        [--check REPOCLOSURE_CHECK_REPOS]
+                        [--dist REPOCLOSURE_TARGET_DIST]
+                        target [target ...]
 
 Run repoclosure for a repository
 
@@ -10,6 +13,10 @@ positional arguments:
 optional arguments:
   -h, --help            show this help message and exit
   -v, --verbose         verbose output
+  --check REPOCLOSURE_CHECK_REPOS
+                        Link to a repository to target for repoclosure
+  --dist REPOCLOSURE_TARGET_DIST
+                        Target dist to test against (e.g. el8)
 
 advanced arguments:
   -e EXTRA_VARS, --extra-vars EXTRA_VARS

--- a/tests/fixtures/testrepo/upstream/package_manifest.yaml
+++ b/tests/fixtures/testrepo/upstream/package_manifest.yaml
@@ -12,6 +12,9 @@ packages:
         dist: '.el7'
       - name: obaltest-nightly-el8
         dist: '.el8'
+    repoclosure_lookaside_repos:
+      rhel7:
+        - el7-base
   hosts:
     hello:
       nightly_package_tito_releaser_args:

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -657,6 +657,22 @@ def test_obal_repoclosure_katello_with_downloaded_rpms():
     ]
     assert_in_mockbin_log(expected_log)
 
+@obal_cli_test(repotype='upstream')
+def test_obal_repoclosure_with_check_repo():
+    assert_obal_success(['repoclosure', 'hello', '--check', 'https://test.example.com/myrepo', '--dist', 'rhel7'])
+
+    expected_log = [
+        "dnf repoclosure",
+        "--newest",
+        "--refresh",
+        "--config",
+        "repoclosure/yum.conf",
+        "--check repo0",
+        "--repofrompath repo0,https://test.example.com/myrepo",
+        "--repo el7-base"
+    ]
+
+    assert_in_mockbin_log(expected_log)
 
 @obal_cli_test(repotype='copr')
 def test_obal_scratch_copr_hello_nowait():


### PR DESCRIPTION
Example:

```
obal-source repoclosure rubygem-pulp_file_client --check https://download.copr.fedorainfracloud.org/results/@theforeman/foreman-katello-nightly-staging-scratch-0b6bfd0a-f472-5d75-9280-3ae62f547728/rhel-8-x86_64/ --dist el8
```

This will allow us to stop downloading RPMs to create a local repository from and instead use the repositories created by the scratch repos from Copr to do repoclosure.