### PR TITLE
Use format and not f-string for Python 2.7

### DIFF
--- a/obal/data/modules/repoclosure.py
+++ b/obal/data/modules/repoclosure.py
@@ -37,7 +37,7 @@ def main():
         command.extend(['--check', name])
 
     for repo in additional_repos:
-        command.extend(['--repofrompath', f"{repo['name']},{repo['url']}"])
+        command.extend(['--repofrompath', '{},{}'.format(repo['name'], repo['url'])])
 
     for repo in lookaside:
         command.extend(['--repo', repo])


### PR DESCRIPTION
f-strings got in my head, and our Python 2.7 tests being busted so missed this. 