### PR TITLE
Correct function description to say it uses rpmbuild

### DIFF
--- a/obal/data/modules/srpm.py
+++ b/obal/data/modules/srpm.py
@@ -121,7 +121,7 @@ def build_srpm(module, package, base_dir, sources_dir, scl=None):
 
 def main():
     """
-    Build a package using tito
+    Build a package using rpmbuild
     """
     module = AnsibleModule(
         argument_spec=dict(


### PR DESCRIPTION
Fixes: bec39978b4595f412b33955af84e06e055dfab7a ("Add srpm-build to replace tito build")