### PR TITLE
explicitly enable the repo to be checked during closure

### DIFF
--- a/obal/data/modules/repoclosure.py
+++ b/obal/data/modules/repoclosure.py
@@ -36,6 +36,7 @@ def main():
 
     for name in check:
         command.extend(['--check', name])
+        command.extend(['--repo', name])
 
     for repo in additional_repos:
         command.extend(['--repofrompath', '{},{}'.format(repo['name'], repo['url'])])

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -612,6 +612,7 @@ def test_obal_repoclosure():
         "--config",
         "repoclosure/yum.conf",
         "--check el7-katello",
+        "--repo el7-katello",
         "--repo el7-base"
     ]
     assert_in_mockbin_log(expected_log)


### PR DESCRIPTION
otherwise dnf happily will check nothing if the repo does not exist