### PR TITLE
Add support for rpmlint folder in the root of inventory_dir

### DIFF
--- a/obal/data/playbooks/lint/lint.yaml
+++ b/obal/data/playbooks/lint/lint.yaml
@@ -7,6 +7,20 @@
   roles:
     - package_variables
   tasks:
+
+    - name: 'Scans for rpmlint file'
+      ansible.builtin.find:
+        path: "{{ inventory_dir }}/rpmlint"
+        file_type: file
+        recurse: true
+        hidden: true
+      register: lintfile
+
+    - name: 'Set rpmlint file when present'
+      set_fact:
+        rpmlint_rc_file: "{{ lintfile.files | map(attribute='path') | first }}"
+      when: lintfile.files | map(attribute='size') | length > 0
+
     - name: 'Set default rpmlint RC file'
       set_fact:
         rpmlint_rc_file: "{{ inventory_dir }}/{{ package_base_dir }}{{ inventory_hostname }}/.rpmlintrc"

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -762,6 +762,11 @@ def test_obal_lint_hello_with_epoch():
 
     assert_mockbin_log(["rpmlint --file {pwd}/packages/hello/.rpmlintrc {pwd}/packages/hello"])
 
+@obal_cli_test(repotype='upstream')
+def test_obal_lint_rpmlint_folder():
+    assert_obal_success(['lint', 'hello'])
+
+    assert_mockbin_log(["rpmlint --file {pwd}/rpmlint/.rpmlintrc {pwd}/packages/hello"])
 
 @obal_cli_test(repotype='upstream_bad_changelog')
 def test_obal_lint_bad_changelog():


### PR DESCRIPTION
This PRs adds support for one folder called rpmlint inside of the inventory_dir.

With Pulp packaging going to Python 3.11, rpmlint is about to break when the Jenkins nodes start to use one ansible version that requires python 3.11 and install python3.11-libs, it will start to complain about the
  dist-utls deprecation in python 3.12+.