### PR TITLE
include repoclosure_target_repos when running repoclosure

### DIFF
--- a/obal/data/roles/repoclosure/tasks/main.yml
+++ b/obal/data/roles/repoclosure/tasks/main.yml
@@ -26,7 +26,7 @@
     loop_var: repo_url
     index_var: index
   vars:
-    check_repos: "{{ 'repo' + index|string }}"
+    check_repos: "{{ ['repo' + index|string] + repoclosure_target_repos[repoclosure_target_dist]|default([]) }}"
     lookaside_repos: "{{ repoclosure_lookaside_repos[repoclosure_target_dist] }}"
     additional_repos: "{{ [{'name': 'repo' + index|string, 'url': repo_url}] }}"
   when:


### PR DESCRIPTION
otherwise we do not conside the repo we build into for closure, which can have funny results