### PR TITLE
Depend on ansible-core on Python 3.6+

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,11 @@ setup(
 
     packages=find_packages(exclude=['contrib', 'docs', 'tests']),
 
-    install_requires=['ansible >= 2.5', 'obsah >= 0.0.3'],
+    install_requires=[
+        'ansible >= 2.5; python_version < 3.6',
+        'ansible-core >= 2.11; python_version >= 3.6',
+        'obsah >= 0.0.3',
+    ],
 
     extras_require={
         'argcomplete': ['argcomplete'],


### PR DESCRIPTION
This makes packaging on Fedora easier, where the is no more ansible but only ansible-core.

I still maintain https://copr.fedorainfracloud.org/coprs/ekohl/obal but ran into problems while updating and upgrading to Fedora 39 where ansible has been dropped. I believe we don't depend on any modules outside of ansible-core and our own so it also makes installation in other places faster.