### PR TITLE
Rely on obsah to pull in Ansible

### DIFF
--- a/obal/data/ansible.cfg
+++ b/obal/data/ansible.cfg
@@ -3,7 +3,6 @@ inventory = package_manifest.yaml
 retry_files_enabled = False
 transport = local
 nocows = 1
-stdout_callback = yaml
 display_skipped_hosts = false
 roles_path = ./roles/
 library = ./modules

--- a/obal/data/roles/fetch_sources/tasks/main.yml
+++ b/obal/data/roles/fetch_sources/tasks/main.yml
@@ -18,9 +18,11 @@
         depth: 1
 
     - name: 'Copy upstream files'
-      ansible.posix.synchronize:
+      ansible.builtin.copy:
         src: "{{ obal_tmp_dir }}/{{ upstream_directory }}/{{ item }}"
         dest: "{{ inventory_dir }}/{{ package_base_dir }}/{{ inventory_hostname }}/"
+        mode: '0640'
+        directory_mode: '0750'
       with_items: "{{ upstream_files }}"
   rescue:
     - name: 'Remove package directory'
@@ -58,9 +60,11 @@
         chdir: "{{ obal_tmp_dir }}/{{ inventory_hostname }}"
 
     - name: 'Copy upstream files'
-      ansible.posix.synchronize:
+      ansible.builtin.copy:
         src: "{{ obal_tmp_dir }}/{{ inventory_hostname }}/{{ item }}"
         dest: "{{ inventory_dir }}/{{ package_base_dir }}/{{ inventory_hostname }}/"
+        mode: '0640'
+        directory_mode: '0750'
       with_items: "{{ upstream_files }}"
   rescue:
     - name: 'Remove package directory'

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ setup(
 
     packages=find_packages(exclude=['contrib', 'docs', 'tests']),
 
-    install_requires=['ansible >= 2.5', 'obsah >= 0.0.3'],
+    install_requires=['obsah >= 0.0.3'],
 
     extras_require={
         'argcomplete': ['argcomplete'],


### PR DESCRIPTION
obsah already pulls in either ansible or ansible-core, depending on the Python version. There's no need for obal itself to pull it in.