### PR TITLE
use yaml output in the default callback

### DIFF
--- a/obal/data/ansible.cfg
+++ b/obal/data/ansible.cfg
@@ -8,3 +8,5 @@ roles_path = ./roles/
 library = ./modules
 module_utils = ./module_utils
 deprecation_warnings = False
+callback_format_pretty = true
+callback_result_format = yaml


### PR DESCRIPTION
before:

```
TASK [repoclosure : Run repoclosure] ****************************************
fatal: [foreman-staging-repoclosure-el8]: FAILED! => {"changed": false, "command": "dnf repoclosure --refresh --newest --config /tmp/ansible.bmt_ue75repoclosure/yum.conf --check el8-foreman-nightly-staging --repo el8-foreman-nightly-staging --repo el8-baseos --repo el8-appstream --repo el8-powertools --repo el8-extras --repo el8-puppet-7 --repo el8-candlepin-4.3-staging", "msg": "Repoclosure failed", "output": "Unable to detect release version (use '--releasever' to specify release version)\nError: Repoclosure ended with unresolved dependencies (1) across 1 packages.\npackage: rubygem-sassc-2.4.0-2.el8.x86_64 from el8-foreman-nightly-staging\n  unresolved deps (1):\n    (libsass.so.1 if libc.so.6)\n"}
```

after:
```
TASK [repoclosure : Run repoclosure] ****************************************
fatal: [foreman-staging-repoclosure-el8]: FAILED! =>
    changed: false
    command: dnf repoclosure --refresh --newest --config /tmp/ansible.vsmlz8rprepoclosure/yum.conf
        --check el8-foreman-nightly-staging --repo el8-foreman-nightly-staging --repo
        el8-baseos --repo el8-appstream --repo el8-powertools --repo el8-extras --repo
        el8-puppet-7 --repo el8-candlepin-4.3-staging
    msg: Repoclosure failed
    output: |-
        Unable to detect release version (use '--releasever' to specify release version)
        Error: Repoclosure ended with unresolved dependencies (1) across 1 packages.
        package: rubygem-sassc-2.4.0-2.el8.x86_64 from el8-foreman-nightly-staging
          unresolved deps (1):
            (libsass.so.1 if libc.so.6)
```

Fixes: 8331644c975b3767760da1e0e2a0d67728d977bd