### PR TITLE
only check repoclosure for noarch and x86_64 RPMs

### DIFF
--- a/obal/data/modules/repoclosure.py
+++ b/obal/data/modules/repoclosure.py
@@ -17,6 +17,7 @@ def main():
             check=dict(type='list', required=True),
             additional_repos=dict(type='list', required=False, default=[]),
             lookaside=dict(type='list', required=False, default=[]),
+            arch=dict(type='list', required=False, default=['noarch', 'x86_64']),
         )
     )
 
@@ -33,6 +34,9 @@ def main():
         '--config',
         config
     ]
+
+    for arch in module.params['arch']:
+        command.extend(['--arch', arch])
 
     for name in check:
         command.extend(['--check', name])


### PR DESCRIPTION
especially, don't check src, as they might have deps on development tooling, that is not present in normal lookaside repos.

this is only really neccessary for copr repos that ship both src and binary in the same repo.