### PR TITLE
Use koji_build for scratch when koji_tags are present for tito

### DIFF
--- a/obal/data/roles/build_package/tasks/koji.yml
+++ b/obal/data/roles/build_package/tasks/koji.yml
@@ -1,7 +1,19 @@
 ---
 - name: 'Use tito to build package'
-  include_tasks: tito_release.yml
   when: not build_package_use_koji_build
+  block:
+    - name: Scratch build with koji_build
+      when:
+        - build_package_scratch
+        - koji_tags
+      include_tasks: koji_build.yml
+      loop: "{{ koji_tags }}"
+      loop_control:
+        loop_var: tag
+
+    - name: Release with tito
+      when: (build_package_scratch and not koji_tags) or (not build_package_scratch)
+      include_tasks: tito_release.yml
 
 - when: build_package_use_koji_build
   block:

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -140,9 +140,10 @@ def test_obal_scratch_with_tito_upstream_hello():
     assert os.path.exists('packages/hello/hello-2.10.tar.gz')
 
     expected_log = [
-        "tito release --yes --scratch dist-git",
+        "koji build obaltest-nightly-rhel7 /tmp/SRPMs/hello-2.10-2.src.rpm --scratch",
         "koji watch-task 1234",
-        "koji taskinfo -v 1234",
+        "koji build obaltest-nightly-el8 /tmp/SRPMs/hello-2.10-2.src.rpm --scratch",
+        "koji watch-task 1234"
     ]
     assert_mockbin_log(expected_log)
 
@@ -154,7 +155,8 @@ def test_obal_scratch_with_tito_upstream_hello_nowait():
     assert os.path.exists('packages/hello/hello-2.10.tar.gz')
 
     expected_log = [
-        "tito release --yes --scratch dist-git"
+        "koji build obaltest-nightly-rhel7 /tmp/SRPMs/hello-2.10-2.src.rpm --scratch",
+        "koji build obaltest-nightly-el8 /tmp/SRPMs/hello-2.10-2.src.rpm --scratch"
     ]
     assert_mockbin_log(expected_log)
 


### PR DESCRIPTION
This allows incremental switchover to koji/brew build from tito by allowing scratch builds to flow through koji_build if koji_tags are defined. 