### PR TITLE
Fix unversioned obsoletes warning from rpmlint

### DIFF
--- a/tests/fixtures/testrepo/upstream/packages/hello/hello.spec
+++ b/tests/fixtures/testrepo/upstream/packages/hello/hello.spec
@@ -18,7 +18,7 @@ BuildRequires: gettext
 Requires(post): info
 Requires(preun): info
 
-Obsoletes: goodbye
+Obsoletes: goodbye < 2
 
 %description
 The "Hello World" program, done with all bells and whistles of a proper FOSS


### PR DESCRIPTION
In 83b20f0c4fd9f82772cd9f83792ca0d9ae658c0c an Obsoletes statement was added, but rpmlint doesn't like unversioned obsoletes and causes the build to fail.