### PR TITLE
Use 'is truthy' for remaining bare boolean conditionals

### DIFF
--- a/obal/data/roles/build_package/tasks/copr_build.yml
+++ b/obal/data/roles/build_package/tasks/copr_build.yml
@@ -72,7 +72,7 @@
       when: (build_package_copr_status is failed)
 
 - when:
-    - build_package_archive_build_info
+    - build_package_archive_build_info is truthy
     - copr_builds is changed
   block:
     - name: Create build info directory
@@ -83,7 +83,7 @@
 
     - name: 'Write out build info'
       when:
-        - build_package_archive_build_info
+        - build_package_archive_build_info is truthy
       copy:
         dest: "{{ inventory_dir }}/copr_build_info/{{ inventory_hostname }}"
         content: "{{ copr_builds | to_yaml }}"

--- a/obal/data/roles/build_package/tasks/koji.yml
+++ b/obal/data/roles/build_package/tasks/koji.yml
@@ -1,21 +1,21 @@
 ---
 - name: 'Use tito to build package'
-  when: not build_package_use_koji_build
+  when: build_package_use_koji_build is not truthy
   block:
     - name: Scratch build with koji_build
       when:
-        - build_package_scratch
-        - koji_tags
+        - build_package_scratch is truthy
+        - koji_tags is truthy
       include_tasks: koji_build.yml
       loop: "{{ koji_tags }}"
       loop_control:
         loop_var: tag
 
     - name: Release with tito
-      when: (build_package_scratch and not koji_tags) or (not build_package_scratch)
+      when: (build_package_scratch is truthy and koji_tags is not truthy) or (build_package_scratch is not truthy)
       include_tasks: tito_release.yml
 
-- when: build_package_use_koji_build
+- when: build_package_use_koji_build is truthy
   block:
     - include_tasks: koji_build.yml
       loop: "{{ koji_tags }}"

--- a/obal/data/roles/build_package/tasks/tito_release.yml
+++ b/obal/data/roles/build_package/tasks/tito_release.yml
@@ -10,12 +10,12 @@
 - name: 'Set tito_releasers for brew scratch'
   set_fact:
     build_package_tito_releasers: "{{ releasers | map('replace', 'dist-git', 'scratch') | list }}"
-  when: build_package_koji_command == 'brew' and build_package_scratch
+  when: build_package_koji_command == 'brew' and build_package_scratch is truthy
 
 - name: 'Set tito_releasers'
   set_fact:
     build_package_tito_releasers: "{{ releasers }}"
-  when: build_package_koji_command != 'brew' or not build_package_scratch
+  when: build_package_koji_command != 'brew' or build_package_scratch is not truthy
 
 - name: 'Release to {{ build_package_koji_command }}'
   tito_release:

--- a/obal/data/roles/diff_package/tasks/main.yml
+++ b/obal/data/roles/diff_package/tasks/main.yml
@@ -1,9 +1,9 @@
 ---
 - name: 'Include {{ diff_package_type }} package diff'
   include_tasks: "{{ diff_package_type }}.yml"
-  when: not diff_package_skip
+  when: diff_package_skip is not truthy
 
 - name: 'Set diff_package_changed to True when skipping package diffs'
   set_fact:
     diff_package_changed: true
-  when: diff_package_skip
+  when: diff_package_skip is truthy


### PR DESCRIPTION
## Summary
- Replace bare boolean conditionals missed by #420 with `is truthy` / `is not truthy`
- Fixes Ansible 2.20+ failures when variables are passed as strings via `-e`
- Affected: `build_package_archive_build_info`, `build_package_scratch`, `build_package_use_koji_build`, `diff_package_skip`, `koji_tags`

## Test plan
- [x] `obal scratch rubygem-snaky_hash -e build_package_archive_build_info=True` succeeds