### PR TITLE
Return user, project, and chroot from copr_build module

### DIFF
--- a/obal/data/modules/copr_build.py
+++ b/obal/data/modules/copr_build.py
@@ -112,7 +112,8 @@ def main():
         build_urls = re.findall(r'^Build was added to.+:\n^\s+(.+)\s*', output, re.MULTILINE)
         builds = re.findall(r'^Created builds:\s(\d+)', output, re.MULTILINE)
 
-        module.exit_json(changed=True, output=output, builds=builds, build_urls=build_urls)
+        module.exit_json(changed=True, output=output, builds=builds, build_urls=build_urls,
+                         user=user, project=project, chroot=chroot)
     else:
         module.exit_json(changed=False)
 


### PR DESCRIPTION
## Summary
- Add `user`, `project`, and `chroot` to `copr_build` module's `exit_json` output
- Newer Ansible no longer includes `invocation.module_args` in registered results, breaking tooling that needs these values to construct COPR repo URLs

## Test plan
- [x] Scratch build with `build_package_archive_build_info=True` writes YAML containing `user` and `project` fields