### PR TITLE
Scope repoclosure's persistent-repo exclude to the package's own binary names

### DIFF
--- a/obal/data/modules/repoclosure.py
+++ b/obal/data/modules/repoclosure.py
@@ -7,24 +7,16 @@ from subprocess import check_output, CalledProcessError, STDOUT
 from ansible.module_utils.basic import AnsibleModule
 
 
-def main():
+def build_command(config, check, additional_repos=None, lookaside=None, arch=None,
+                  exclude_repos=None, exclude_packages=None):
     """
-    Run repoclosure on a set of repositories
+    Build the `dnf repoclosure` command line for the given set of repositories
     """
-    module = AnsibleModule(
-        argument_spec=dict(
-            config=dict(type='str', required=True),
-            check=dict(type='list', required=True),
-            additional_repos=dict(type='list', required=False, default=[]),
-            lookaside=dict(type='list', required=False, default=[]),
-            arch=dict(type='list', required=False, default=['noarch', 'x86_64']),
-        )
-    )
-
-    config = module.params['config']
-    check = module.params['check']
-    additional_repos = module.params['additional_repos']
-    lookaside = module.params['lookaside']
+    additional_repos = additional_repos or []
+    lookaside = lookaside or []
+    arch = arch or ['noarch', 'x86_64']
+    exclude_repos = exclude_repos or []
+    exclude_packages = exclude_packages or []
 
     command = [
         'dnf',
@@ -36,8 +28,8 @@ def main():
         config
     ]
 
-    for arch in module.params['arch']:
-        command.extend(['--arch', arch])
+    for one_arch in arch:
+        command.extend(['--arch', one_arch])
 
     for name in check:
         command.extend(['--check', name])
@@ -48,6 +40,46 @@ def main():
 
     for repo in lookaside:
         command.extend(['--repo', repo])
+
+    # Exclude the package(s) under test from specific (e.g. persistent staging)
+    # repos, so a stale sibling build there (e.g. a self-pinned "-doc"
+    # subpackage requiring "%{name} = %{version}-%{release}") isn't flagged as
+    # broken once a newer build of the same package supersedes it elsewhere.
+    # Other repos are left untouched, so real cross-package regressions
+    # (a different package still capping this one below its new version)
+    # keep failing loudly.
+    for repo in exclude_repos:
+        for package in exclude_packages:
+            command.append('--setopt={}.excludepkgs={}'.format(repo, package))
+
+    return command
+
+
+def main():
+    """
+    Run repoclosure on a set of repositories
+    """
+    module = AnsibleModule(
+        argument_spec=dict(
+            config=dict(type='str', required=True),
+            check=dict(type='list', required=True),
+            additional_repos=dict(type='list', required=False, default=[]),
+            lookaside=dict(type='list', required=False, default=[]),
+            arch=dict(type='list', required=False, default=['noarch', 'x86_64']),
+            exclude_repos=dict(type='list', required=False, default=[]),
+            exclude_packages=dict(type='list', required=False, default=[]),
+        )
+    )
+
+    command = build_command(
+        config=module.params['config'],
+        check=module.params['check'],
+        additional_repos=module.params['additional_repos'],
+        lookaside=module.params['lookaside'],
+        arch=module.params['arch'],
+        exclude_repos=module.params['exclude_repos'],
+        exclude_packages=module.params['exclude_packages'],
+    )
 
     try:
         output = check_output(command, universal_newlines=True, stderr=STDOUT)

--- a/obal/data/roles/repoclosure/meta/main.yml
+++ b/obal/data/roles/repoclosure/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - role: package_variables

--- a/obal/data/roles/repoclosure/tasks/downloaded_rpms_repoclosure.yml
+++ b/obal/data/roles/repoclosure/tasks/downloaded_rpms_repoclosure.yml
@@ -18,6 +18,10 @@
     check_repos: "{{ repoclosure_target_repos[dist] | default([]) + ['downloaded_rpms'] }}"
     additional_repos: "{{ repoclosure_additional_repos + [download_rpm_repos] }}"
     lookaside_repos: "{{ repoclosure_lookaside_repos[dist] }}"
+    # downloaded_rpms is the freshly-built repo for this package - exclude its
+    # stale sibling from the persistent staging repos only.
+    exclude_repos: "{{ repoclosure_target_repos[dist]|default([]) }}"
+    exclude_packages: "{{ resolved_exclude_packages }}"
   loop: "{{ downloaded_rpms_dists }}"
   loop_control:
     loop_var: dist

--- a/obal/data/roles/repoclosure/tasks/main.yml
+++ b/obal/data/roles/repoclosure/tasks/main.yml
@@ -1,4 +1,7 @@
 ---
+- name: Resolve packages to exclude from persistent staging repos
+  include_tasks: resolve_exclude_packages.yml
+
 - name: Run repoclosure for all dists
   include_tasks: downloaded_rpms_repoclosure.yml
   when:
@@ -29,5 +32,10 @@
     check_repos: "{{ ['repo' + index|string] + repoclosure_target_repos[repoclosure_target_dist]|default([]) }}"
     lookaside_repos: "{{ repoclosure_lookaside_repos[repoclosure_target_dist] }}"
     additional_repos: "{{ [{'name': 'repo' + index|string, 'url': repo_url}] }}"
+    # repo0 (repo_url, the freshly-built PR/scratch repo) is authoritative for
+    # this package - exclude its stale sibling from the persistent staging
+    # repos only, not from repo0 itself.
+    exclude_repos: "{{ repoclosure_target_repos[repoclosure_target_dist]|default([]) }}"
+    exclude_packages: "{{ resolved_exclude_packages }}"
   when:
     - repoclosure_check_repos is truthy

--- a/obal/data/roles/repoclosure/tasks/repoclosure.yml
+++ b/obal/data/roles/repoclosure/tasks/repoclosure.yml
@@ -28,6 +28,8 @@
         check: "{{ check_repos | default([]) }}"
         additional_repos: "{{ additional_repos | default([]) }}"
         lookaside: "{{ lookaside_repos | default([]) }}"
+        exclude_repos: "{{ exclude_repos | default([]) }}"
+        exclude_packages: "{{ exclude_packages | default([]) }}"
       register: output
 
     - debug:

--- a/obal/data/roles/repoclosure/tasks/resolve_exclude_packages.yml
+++ b/obal/data/roles/repoclosure/tasks/resolve_exclude_packages.yml
@@ -1,0 +1,66 @@
+---
+# Resolve the exact binary package names built by this host's spec, so a
+# persistent staging repo can have just this package's own (possibly stale)
+# builds excluded without touching unrelated packages whose names happen to
+# share a prefix (e.g. "foreman" vs "foreman-proxy", "rubygem-hammer_cli" vs
+# "rubygem-hammer_cli_foreman"). Hosts with no package directory (e.g. the
+# repoclosure-only hosts used for a full-dist self-check) resolve to an empty
+# list - there's no package here to scope an exclude to.
+- name: Check for a package directory for this host
+  stat:
+    path: "{{ inventory_dir }}/{{ package_base_dir }}/{{ inventory_hostname }}"
+  register: repoclosure_package_dir
+
+- name: Find spec file for exclude-package resolution
+  find:
+    pattern: "*.spec"
+    paths: "{{ inventory_dir }}/{{ package_base_dir }}/{{ inventory_hostname }}"
+  register: repoclosure_spec_file
+  when: repoclosure_package_dir.stat.exists and repoclosure_package_dir.stat.isdir
+
+- name: Get binary package names built by the spec
+  # list form (not a plain string) - the command module's shlex splitting of a
+  # string would eat the backslash in "%{name}\n" (rpm's own queryformat
+  # engine is what turns that "\n" into a real newline, not the shell), so
+  # each argv item must be passed through untouched.
+  command:
+    argv:
+      - rpmspec
+      - --query
+      - --undefine=dist
+      - --undefine=foremandist
+      - --queryformat=%{name}\n
+      - "{{ repoclosure_spec_file.files[0].path }}"
+  register: repoclosure_binary_names
+  changed_when: false
+  failed_when: false
+  when: repoclosure_spec_file is defined and (repoclosure_spec_file.matched | default(0)) > 0
+
+- name: Record whether a package directory exists for this host
+  set_fact:
+    repoclosure_has_package_dir: "{{ repoclosure_package_dir.stat.exists and repoclosure_package_dir.stat.isdir }}"
+
+- name: Record whether the spec resolved at least one binary package name
+  set_fact:
+    repoclosure_spec_resolved: >-
+      {{ repoclosure_binary_names is defined and
+         (repoclosure_binary_names.rc | default(1)) == 0 and
+         (repoclosure_binary_names.stdout_lines | default([]) | length) > 0 }}
+
+# Exact binary names from a successfully-parsed spec; if the spec failed to
+# parse, fall back to the exact hostname (never a glob); if there's no
+# package directory at all, nothing to exclude.
+- name: Use the spec's binary package names when resolution succeeded
+  set_fact:
+    resolved_exclude_packages: "{{ repoclosure_binary_names.stdout_lines }}"
+  when: repoclosure_spec_resolved
+
+- name: Fall back to the exact hostname when a package exists but its spec didn't resolve
+  set_fact:
+    resolved_exclude_packages: "{{ [inventory_hostname] }}"
+  when: repoclosure_has_package_dir and not repoclosure_spec_resolved
+
+- name: No package directory means there's nothing to exclude
+  set_fact:
+    resolved_exclude_packages: []
+  when: not repoclosure_has_package_dir

--- a/tests/fixtures/testrepo/upstream/package_manifest.yaml
+++ b/tests/fixtures/testrepo/upstream/package_manifest.yaml
@@ -19,6 +19,9 @@ packages:
     hello:
       nightly_package_tito_releaser_args:
         - "jenkins_job=hello-master-release"
+      repoclosure_target_repos:
+        rhel7:
+          - el7-katello
     foo: {}
     bar: {}
     package-with-existing-build: {}
@@ -28,6 +31,14 @@ packages:
           dist: '.el8'
         - name: obalclient-nightly-el8
           dist: '.el8'
+      repoclosure_target_repos:
+        rhel7:
+          - el7-katello
+          - el7-updates
+    broken-spec-package:
+      repoclosure_target_repos:
+        rhel7:
+          - el7-katello
 
 repoclosures:
   vars:
@@ -45,3 +56,8 @@ repoclosures:
       repoclosure_target_repos:
         rhel7:
           - el7-katello
+    katello-multi-repoclosure:
+      repoclosure_target_repos:
+        rhel7:
+          - el7-katello
+          - el7-updates

--- a/tests/fixtures/testrepo/upstream/packages/broken-spec-package/broken-spec-package.spec
+++ b/tests/fixtures/testrepo/upstream/packages/broken-spec-package/broken-spec-package.spec
@@ -1,0 +1,14 @@
+%if 0%{?this_is_intentionally_unterminated}
+Name: broken-spec-package
+Version: 1.0
+Release: 1%{?dist}
+Summary: A spec with an unterminated conditional, to exercise the exclude-resolver's fallback branch
+
+License: GPLv3+
+
+%description
+This spec is intentionally unparseable by rpmspec (missing %endif) so that
+resolve_exclude_packages.yml's "spec exists but failed to parse" fallback
+branch has real functional test coverage instead of only ad-hoc manual checks.
+
+%files

--- a/tests/fixtures/testrepo/upstream/packages/hello/hello.spec
+++ b/tests/fixtures/testrepo/upstream/packages/hello/hello.spec
@@ -24,6 +24,14 @@ Obsoletes: goodbye < 2
 The "Hello World" program, done with all bells and whistles of a proper FOSS
 project, including configuration, build, internationalization, help files, etc.
 
+%package doc
+Summary: Documentation for %{name}
+Requires: %{name} = %{version}-%{release}
+BuildArch: noarch
+
+%description doc
+Documentation for %{name}.
+
 %prep
 %autosetup
 

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -655,6 +655,10 @@ def test_obal_repoclosure_with_downloaded_rpms():
     ]
     assert_in_mockbin_log(expected_log)
 
+    # dist-repoclosure has no repoclosure_target_repos, so there's nothing
+    # persistent/stale to exclude the package from.
+    assert_not_in_mockbin_log("--setopt")
+
 
 @obal_cli_test(repotype='upstream')
 def test_obal_repoclosure_katello_with_downloaded_rpms():
@@ -677,6 +681,32 @@ def test_obal_repoclosure_katello_with_downloaded_rpms():
     ]
     assert_in_mockbin_log(expected_log)
 
+    # katello-repoclosure is a repoclosure-only host with no package
+    # directory/spec - there's no real package here to scope an exclude to,
+    # so nothing should be excluded (excluding "katello-repoclosure*" would be
+    # meaningless at best, and a name-collision hazard at worst).
+    assert_not_in_mockbin_log("--setopt")
+
+
+@obal_cli_test(repotype='upstream')
+def test_obal_repoclosure_downloaded_rpms_real_package():
+    # unlike katello-repoclosure above, this exercises the downloaded_rpms
+    # flow for an actual package host (koji/copr release flow shape) with a
+    # multi-binary spec (hello + hello-doc, see hello.spec's %package doc).
+    os.makedirs('downloaded_rpms/rhel7')
+
+    assert_obal_success(['repoclosure', 'hello'])
+
+    # both binary packages built by hello.spec get excluded from the
+    # persistent target repo, by exact name - never a glob.
+    assert_in_mockbin_log("--setopt=el7-katello.excludepkgs=hello")
+    assert_in_mockbin_log("--setopt=el7-katello.excludepkgs=hello-doc")
+    assert_not_in_mockbin_log("--setopt=el7-katello.excludepkgs=hello*")
+    # downloaded_rpms itself must never be excluded from its own check.
+    assert_not_in_mockbin_log("--setopt=downloaded_rpms.excludepkgs=hello")
+    assert_not_in_mockbin_log("--setopt=downloaded_rpms.excludepkgs=hello-doc")
+
+
 @obal_cli_test(repotype='upstream')
 def test_obal_repoclosure_with_check_repo():
     assert_obal_success(['repoclosure', 'hello', '--check', 'https://test.example.com/myrepo', '--dist', 'rhel7'])
@@ -690,10 +720,69 @@ def test_obal_repoclosure_with_check_repo():
         "repoclosure/yum.conf",
         "--check repo0",
         "--repofrompath repo0,https://test.example.com/myrepo",
+        "--check el7-katello",
         "--repo el7-base"
     ]
 
     assert_in_mockbin_log(expected_log)
+
+    # the persistent target repo (el7-katello) gets both of hello.spec's
+    # binary packages excluded, by exact name - since repo0 (the fresh
+    # PR/scratch build) is authoritative for them...
+    assert_in_mockbin_log("--setopt=el7-katello.excludepkgs=hello")
+    assert_in_mockbin_log("--setopt=el7-katello.excludepkgs=hello-doc")
+    # ...never as a name-prefix glob, which would also match unrelated
+    # packages that merely share a name prefix (e.g. "hello" vs "hello-world").
+    assert_not_in_mockbin_log("--setopt=el7-katello.excludepkgs=hello*")
+    # ...and repo0 itself must never be excluded from its own check.
+    assert_not_in_mockbin_log("--setopt=repo0.excludepkgs=hello")
+    assert_not_in_mockbin_log("--setopt=repo0.excludepkgs=hello-doc")
+
+
+@obal_cli_test(repotype='upstream')
+def test_obal_repoclosure_with_check_repo_no_package_dir():
+    # katello-multi-repoclosure is a repoclosure-only host (no package
+    # directory/spec), even though it has two repoclosure_target_repos
+    # configured. There's no real package to scope an exclude to, so no
+    # --setopt should be emitted at all, regardless of how many target repos
+    # are configured.
+    assert_obal_success([
+        'repoclosure', 'katello-multi-repoclosure',
+        '--check', 'https://test.example.com/myrepo', '--dist', 'rhel7'
+    ])
+
+    assert_not_in_mockbin_log("--setopt")
+
+
+@obal_cli_test(repotype='upstream')
+def test_obal_repoclosure_with_check_repo_multiple_target_repos():
+    # package-with-two-targets is a real package host (single binary package)
+    # with two repoclosure_target_repos configured for rhel7.
+    assert_obal_success([
+        'repoclosure', 'package-with-two-targets',
+        '--check', 'https://test.example.com/myrepo', '--dist', 'rhel7'
+    ])
+
+    # every persistent target repo gets its own exclude, not just the first
+    assert_in_mockbin_log("--setopt=el7-katello.excludepkgs=package-with-two-targets")
+    assert_in_mockbin_log("--setopt=el7-updates.excludepkgs=package-with-two-targets")
+    assert_not_in_mockbin_log("--setopt=repo0.excludepkgs=package-with-two-targets")
+
+
+@obal_cli_test(repotype='upstream')
+def test_obal_repoclosure_with_check_repo_unparseable_spec():
+    # broken-spec-package has a real package directory but its spec has an
+    # unterminated %if, so rpmspec fails to parse it. The resolver must fall
+    # back to the exact hostname (never a glob) rather than silently
+    # excluding nothing.
+    assert_obal_success([
+        'repoclosure', 'broken-spec-package',
+        '--check', 'https://test.example.com/myrepo', '--dist', 'rhel7'
+    ])
+
+    assert_in_mockbin_log("--setopt=el7-katello.excludepkgs=broken-spec-package")
+    assert_not_in_mockbin_log("--setopt=el7-katello.excludepkgs=broken-spec-package*")
+    assert_not_in_mockbin_log("--setopt=repo0.excludepkgs=broken-spec-package")
 
 @obal_cli_test(repotype='copr')
 def test_obal_scratch_copr_hello_nowait():

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -1,4 +1,5 @@
 from obal.data.module_utils.obal import get_specfile_sources, get_changelog_evr
+from obal.data.modules.repoclosure import build_command
 
 
 def test_get_specfile_sources():
@@ -8,3 +9,41 @@ def test_get_specfile_sources():
 def test_get_changelog_evr():
     evr = get_changelog_evr('tests/fixtures/testrepo/upstream/packages/hello/hello.spec')
     assert evr == '2.10-2'
+
+
+def test_repoclosure_build_command_no_excludes():
+    command = build_command('repoclosure/yum.conf', ['repo0', 'el7-base'])
+
+    assert '--setopt' not in ' '.join(command)
+
+
+def test_repoclosure_build_command_exclude_repos_without_packages_is_noop():
+    # exclude_repos with no exclude_packages (or vice versa) must not emit a
+    # bare/broken --setopt - the cartesian product is simply empty.
+    command = build_command('repoclosure/yum.conf', ['repo0'], exclude_repos=['el7-base'])
+
+    assert '--setopt' not in ' '.join(command)
+
+
+def test_repoclosure_build_command_excludes_only_target_repos():
+    command = build_command(
+        'repoclosure/yum.conf', ['repo0', 'el7-base'],
+        additional_repos=[{'name': 'repo0', 'url': 'https://example.com/repo0'}],
+        exclude_repos=['el7-base'],
+        exclude_packages=['hello*'],
+    )
+
+    assert '--setopt=el7-base.excludepkgs=hello*' in command
+    assert not any(opt.startswith('--setopt=repo0.') for opt in command)
+
+
+def test_repoclosure_build_command_excludes_are_a_cartesian_product():
+    command = build_command(
+        'repoclosure/yum.conf', ['repo0'],
+        exclude_repos=['el7-base', 'el7-katello'],
+        exclude_packages=['hello*', 'world*'],
+    )
+
+    for repo in ('el7-base', 'el7-katello'):
+        for package in ('hello*', 'world*'):
+            assert '--setopt={}.excludepkgs={}'.format(repo, package) in command


### PR DESCRIPTION
## Summary

`--newest --best` (#436) resolves `Requires` against the newest package across *all* repos
combined, while still checking every repo's own newest package in isolation. A subpackage that
self-pins via `Requires: %{name} = %{version}-%{release}` (e.g. a `-doc`/`-cockpit` sibling)
then false-positives the instant a newer build of the same SRPM lands anywhere else in the
checked set — the persistent staging repo's stale copy has nothing left to satisfy its exact
pin against.

Reproduced against the real `theforeman/foreman-packaging#13921` and `#13922` CI failures
(`rubygem-foreman_remote_execution` and `rubygem-foreman_leapp` bumps), using the live
`el9-foreman-plugins-nightly-staging` repo and the real `repoclosure/yum.conf`.

## Fix

Exclude the package under test from the persistent staging repos it's checked against, since
the PR's own freshly-built repo (`repo0`/`downloaded_rpms`) is authoritative for it. Scoped
with dnf's per-repo `--setopt=<repo>.excludepkgs=`, never applied to the fresh repo itself.

Exclude list is resolved to the package's **exact binary names** via `rpmspec`, never a
name-prefix glob — a glob would also match unrelated packages sharing a name prefix (e.g.
`foreman*` also matching `foreman-proxy`, `rubygem-hammer_cli*` also matching
`rubygem-hammer_cli_foreman`), silently masking a real cross-package regression on those
packages — exactly the failure mode `--best` (#436) exists to catch
(`theforeman/foreman-packaging#13647`/`#13661`/`#13688`). Falls back to the exact hostname
(never a glob) if the spec fails to parse; resolves to no exclusion at all for repoclosure-only
hosts with no package directory.

## Testing

- New unit tests for `repoclosure.py`'s extracted `build_command()`.
- New/updated functional tests covering: single and multiple persistent target repos, the
  `downloaded_rpms` release flow, repoclosure-only (spec-less) hosts, and a package with an
  intentionally unparseable spec (exercises the exact-hostname fallback branch).
- Full suite: 135 passed. `pylint`: 10.00/10.
- Manually re-validated against real dnf4 (matching the CI environment) with synthetic and
  live-repo reproductions of both the original false positive and the cross-package regression
  `--best` must keep catching.

🤖 Generated with [Claude Code](https://claude.com/claude-code)